### PR TITLE
Update release 24.07 README.md

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -5,7 +5,7 @@
 
 ## 1. Overview
 
-The pre-production Intel® Tiber™ Broadcast Suite, version 0.9, is a software-based package, modular video production pipeline, designed for creation of high-performance and high-quality solutions used in live video production.
+The Intel® Tiber™ Broadcast Suite, release 24.07, is a software-based package, modular video production pipeline, designed for creation of high-performance and high-quality solutions used in live video production.
 The video pipelines are built using Intel-optimized version of FFmpeg and combine: media transport protocols (SMPTE ST 2110-compliant), JPEG XS encoding/decoding, GPU media processing and rendering.
 
 ## 2. Intel® Tiber™ Broadcast Suite


### PR DESCRIPTION
The `pre-production` and `0.9` strings changed to valid ones `The Intel® Tiber™ Broadcast Suite, release 24.07 [...]`