### PR TITLE
gRPC POC service and client for FFmpeg wrapper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 docs/_build
 _build
+gRPC/build
 file*.json
 .reports
 NVMUpdatePackage

--- a/gRPC/CMakeLists.txt
+++ b/gRPC/CMakeLists.txt
@@ -1,0 +1,100 @@
+#SPDX-FileCopyrightText: Copyright (c) 2024 Intel Corporation
+#
+#SPDX-License-Identifier: BSD-3-Clause
+
+cmake_minimum_required(VERSION 3.8)
+
+project(ffmpeg_cmd_wrap C CXX)
+
+
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -pthread")
+
+set(protobuf_MODULE_COMPATIBLE TRUE)
+find_package(Protobuf CONFIG REQUIRED)
+message(STATUS "Using protobuf ${Protobuf_VERSION}")
+
+set(_PROTOBUF_LIBPROTOBUF protobuf::libprotobuf)
+set(_REFLECTION gRPC::grpc++_reflection)
+
+if(CMAKE_CROSSCOMPILING)
+  find_program(_PROTOBUF_PROTOC protoc)
+else()
+  set(_PROTOBUF_PROTOC $<TARGET_FILE:protobuf::protoc>)
+endif()
+
+# Find gRPC installation
+# Looks for gRPCConfig.cmake file installed by gRPC's cmake installation.
+find_package(gRPC CONFIG REQUIRED)
+message(STATUS "Using gRPC ${gRPC_VERSION}")
+
+set(_GRPC_GRPCPP gRPC::grpc++)
+if(CMAKE_CROSSCOMPILING)
+  find_program(_GRPC_CPP_PLUGIN_EXECUTABLE grpc_cpp_plugin)
+else()
+  set(_GRPC_CPP_PLUGIN_EXECUTABLE $<TARGET_FILE:gRPC::grpc_cpp_plugin>)
+endif()
+
+# Proto file
+get_filename_component(hw_proto "./ffmpeg_cmd_wrap.proto" ABSOLUTE)
+get_filename_component(hw_proto_path "${hw_proto}" PATH)
+
+# Generated sources
+set(hw_proto_srcs "${CMAKE_CURRENT_BINARY_DIR}/ffmpeg_cmd_wrap.pb.cc")
+set(hw_proto_hdrs "${CMAKE_CURRENT_BINARY_DIR}/ffmpeg_cmd_wrap.pb.h")
+set(hw_grpc_srcs "${CMAKE_CURRENT_BINARY_DIR}/ffmpeg_cmd_wrap.grpc.pb.cc")
+set(hw_grpc_hdrs "${CMAKE_CURRENT_BINARY_DIR}/ffmpeg_cmd_wrap.grpc.pb.h")
+add_custom_command(
+      OUTPUT "${hw_proto_srcs}" "${hw_proto_hdrs}" "${hw_grpc_srcs}" "${hw_grpc_hdrs}"
+      COMMAND ${_PROTOBUF_PROTOC}
+      ARGS --grpc_out "${CMAKE_CURRENT_BINARY_DIR}"
+        --cpp_out "${CMAKE_CURRENT_BINARY_DIR}"
+        -I "${hw_proto_path}"
+        --plugin=protoc-gen-grpc="${_GRPC_CPP_PLUGIN_EXECUTABLE}"
+        "${hw_proto}"
+      DEPENDS "${hw_proto}")
+
+# Include generated *.pb.h files
+include_directories("${CMAKE_CURRENT_BINARY_DIR}")
+
+# hw_grpc_proto
+add_library(hw_grpc_proto
+  ${hw_grpc_srcs}
+  ${hw_grpc_hdrs}
+  ${hw_proto_srcs}
+  ${hw_proto_hdrs})
+target_link_libraries(hw_grpc_proto
+  absl::check
+  ${_REFLECTION}
+  ${_GRPC_GRPCPP}
+  ${_PROTOBUF_LIBPROTOBUF})
+
+add_library(FFmpeg_wrapper_client FFmpeg_wrapper_client.cc FFmpeg_wrapper_client.h)
+target_link_libraries(FFmpeg_wrapper_client
+  absl::check
+  ${_REFLECTION}
+  ${_GRPC_GRPCPP}
+  ${_PROTOBUF_LIBPROTOBUF})
+
+add_executable(cmd_pass_client cmd_pass_client.cc)
+  target_link_libraries(cmd_pass_client
+    FFmpeg_wrapper_client
+    hw_grpc_proto
+    absl::check
+    absl::flags
+    absl::flags_parse
+    absl::log
+    ${_REFLECTION}
+    ${_GRPC_GRPCPP}
+    ${_PROTOBUF_LIBPROTOBUF})
+
+add_executable(FFmpeg_wrapper_service FFmpeg_wrapper_service.cc)
+  target_link_libraries(FFmpeg_wrapper_service
+    hw_grpc_proto
+    absl::check
+    absl::flags
+    absl::flags_parse
+    absl::log
+    ${_REFLECTION}
+    ${_GRPC_GRPCPP}
+    ${_PROTOBUF_LIBPROTOBUF})

--- a/gRPC/FFmpeg_wrapper_client.cc
+++ b/gRPC/FFmpeg_wrapper_client.cc
@@ -1,0 +1,92 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2024 Intel Corporation
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include "FFmpeg_wrapper_client.h"
+#include "build/ffmpeg_cmd_wrap.pb.h"
+#include <sstream>
+#include <utility>
+#include <string>
+
+CmdPassClient::CmdPassClient(std::string interface, std::string port) : pending_requests_(0) {
+    std::cout << "------ [start] initiate channel --------" << std::endl;
+
+    std::stringstream ss;
+    std::string channel_config;
+
+    ss << interface << ":" << port;
+
+    channel_config = ss.str();
+
+    std::shared_ptr<Channel> channel = grpc::CreateChannel(channel_config, grpc::InsecureChannelCredentials());
+
+    stub_ = CmdPass::NewStub(channel);
+
+    std::cout << "------ [done] initiate channel --------" << std::endl;
+
+    // Start the thread to process the completion queue
+    cq_thread_ = std::thread(&CmdPassClient::AsyncCompleteRpc, this);
+}
+
+CmdPassClient::~CmdPassClient() {
+    cq_.Shutdown();
+    cq_thread_.join();
+}
+
+void CmdPassClient::FFmpegCmdExec(std::vector<std::pair<std::string, std::string>>& cmd_pairs) {
+
+    ReqCmds req_obj;
+    CmdMsg *cmd_msg;
+    
+    for (const auto& cmd_pair : cmd_pairs) {
+        cmd_msg = req_obj.add_obj();
+        cmd_msg->set_cmd_key(cmd_pair.first);
+        cmd_msg->set_cmd_val(cmd_pair.second);
+    }
+
+    auto* call = new AsyncClientCall;
+
+    ++pending_requests_;
+
+    // Initiate the asynchronous RPC call
+    call->response_reader = stub_->PrepareAsyncFFmpegCmdExec(&call->context, req_obj, &cq_);
+    call->response_reader->StartCall();
+    call->response_reader->Finish(&call->response, &call->status, (void*)call);
+}
+
+void CmdPassClient::AsyncCompleteRpc() {
+    void* got_tag;
+    bool ok = false;
+
+    while (cq_.Next(&got_tag, &ok)) {
+        auto* call = static_cast<AsyncClientCall*>(got_tag);
+
+        if (ok) {
+            if (call->status.ok()) {
+                std::cout << "FFmpeg command executed successfully: " << call->status.error_code() << std::endl;
+            }
+            else {
+                std::cout << "FFmpeg command execution failed:" << std::endl;
+                std::cout << "Status = " << call->status.error_code() << std::endl;
+                std::cout << "Message = " << call->status.error_message() << std::endl;
+                std::cout << "Details = " << call->status.error_details() << std::endl;
+            }
+        }
+        else {
+            std::cout << "RPC failed" << std::endl;
+        }
+
+        delete call;
+
+        if (--pending_requests_ == 0) {
+            all_tasks_completed = true;
+            all_tasks_completed.notify_one();
+        }
+    }
+}
+
+void CmdPassClient::WaitForAllRequests() {
+    all_tasks_completed.wait(false);
+}

--- a/gRPC/FFmpeg_wrapper_client.h
+++ b/gRPC/FFmpeg_wrapper_client.h
@@ -1,0 +1,59 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2024 Intel Corporation
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef _CMD_PASS_CLIENT_H_
+#define _CMD_PASS_CLIENT_H_
+
+#include <iostream>
+#include <memory>
+#include <ostream>
+#include <random>
+#include <string>
+#include <thread>
+#include <utility>
+#include <vector>
+#include <atomic>
+#include "build/ffmpeg_cmd_wrap.pb.h"
+
+#include <grpc/grpc.h>
+#include <grpcpp/channel.h>
+#include <grpcpp/client_context.h>
+#include <grpcpp/create_channel.h>
+#include <grpcpp/security/credentials.h>
+#include "build/ffmpeg_cmd_wrap.grpc.pb.h"
+
+using grpc::Channel;
+using grpc::ClientContext;
+using grpc::CompletionQueue;
+using grpc::Status;
+
+class CmdPassClient {
+public:
+    CmdPassClient(std::string interface, std::string port);
+    ~CmdPassClient();
+
+    void FFmpegCmdExec(std::vector<std::pair<std::string, std::string>>& cmd_pairs);
+    void WaitForAllRequests();
+
+private:
+    void AsyncCompleteRpc();
+
+	// Create a new call object
+    struct AsyncClientCall {
+        FFmpegServiceRes response;
+        ClientContext context;
+        Status status;
+        std::unique_ptr<grpc::ClientAsyncResponseReader<FFmpegServiceRes>> response_reader;
+    };
+
+    std::unique_ptr<CmdPass::Stub> stub_;
+    CompletionQueue cq_;
+    std::thread cq_thread_;
+    std::atomic<int> pending_requests_{0};
+    std::atomic<bool> all_tasks_completed{false};
+};
+
+#endif

--- a/gRPC/FFmpeg_wrapper_service.cc
+++ b/gRPC/FFmpeg_wrapper_service.cc
@@ -1,0 +1,223 @@
+#include <cerrno>
+#include <csignal>
+#include <cstdio>
+#include <iostream>
+#include <sstream>
+#include <thread>
+
+#include "ffmpeg_cmd_wrap.grpc.pb.h"
+#include "ffmpeg_cmd_wrap.pb.h"
+#include <grpc/grpc.h>
+#include <grpc/support/log.h>
+#include <grpcpp/security/server_credentials.h>
+#include <grpcpp/server.h>
+#include <grpcpp/server_builder.h>
+#include <grpcpp/server_context.h>
+
+using grpc::Server;
+using grpc::ServerAsyncResponseWriter;
+using grpc::ServerBuilder;
+using grpc::ServerCompletionQueue;
+using grpc::ServerContext;
+using grpc::Status;
+
+#define FFMPEG_INVALID_COMMAND_STATUS "1"
+#define FFMPEG_INVALID_COMMAND_MSG std::string("Failed to execute ffmpeg command : No commands provided")
+
+#define FFMPEG_APP_EXEC_FAIL_STATUS "-1"
+#define FFMPEG_APP_EXEC_FAIL_MSG std::string("Failed to execute ffmpeg pipeline (popen) : ") + std::strerror(errno)
+
+#define FFMPEG_COMMAND_FAIL_STATUS "2"
+#define FFMPEG_COMMAND_FAIL_MSG std::string("FFmpeg command failed : ")
+
+#define FFMPEG_EXEC_OK_STATUS "0"
+#define FFMPEG_EXEC_OK_MSG std::string("FFmpeg command : ") + std::strerror(errno)
+
+class CmdPassImpl final {
+public:
+  std::atomic<bool> stop;
+
+  void Run(std::string server_address) {
+    ServerBuilder builder;
+    stop = false;
+
+    builder.AddListeningPort(server_address, grpc::InsecureServerCredentials());
+    builder.RegisterService(&service_);
+
+    cq_ = builder.AddCompletionQueue();
+
+    server_ = builder.BuildAndStart();
+
+    std::cout << "[*] Server run and listening on " << server_address
+              << std::endl;
+
+    std::jthread th([&]() {
+      stop.wait(false);
+      std::cout << "[*] Shutting down the server" << std::endl;
+
+      server_->Shutdown();
+      cq_->Shutdown();
+
+      void *ignored_tag;
+      bool ignored_ok;
+      while (cq_->Next(&ignored_tag, &ignored_ok)) {
+      }
+    });
+
+    HandleRpcs();
+  }
+
+  void Shutdown() {
+    stop = true;
+    stop.notify_one();
+  }
+
+private:
+  class CallData {
+  public:
+    CallData(CmdPass::AsyncService *service, grpc::ServerCompletionQueue *cq)
+        : service_(service), cq_(cq), responder_(&ctx_), status_(CREATE) {
+      Proceed();
+    }
+
+    void Proceed() {
+      if (status_ == CREATE) {
+        status_ = PROCESS;
+        service_->RequestFFmpegCmdExec(&ctx_, &request_, &responder_, cq_, cq_,
+                                       this);
+      } else if (status_ == PROCESS) { /* FFmpeg command processing starts */
+        new CallData(service_, cq_);
+
+        std::stringstream ss;
+        ss << "ffmpeg";
+
+        if (request_.obj().empty()) {
+          responder_.Finish(response_,
+                            Status(grpc::INVALID_ARGUMENT,
+                                   FFMPEG_INVALID_COMMAND_STATUS,
+                                   FFMPEG_INVALID_COMMAND_MSG),
+                            this);
+
+          status_ = FINISH;
+          return;
+        }
+
+        for (const auto &cmd : request_.obj()) {
+          ss << " -" << cmd.cmd_key() << " " << cmd.cmd_val();
+        }
+
+        std::string ffmpeg_full_cmd = ss.str();
+
+        std::array<char, 128> buffer;
+        std::string result;
+
+        FILE *pipe = popen(ffmpeg_full_cmd.c_str(), "r");
+        if (!pipe) { /* FFmpeg pipeline/execution failed i.e memory allocation
+                      */
+          responder_.Finish(response_,
+                            Status(grpc::INTERNAL, FFMPEG_APP_EXEC_FAIL_STATUS,
+                                   FFMPEG_APP_EXEC_FAIL_MSG),
+                            this);
+
+          status_ = FINISH;
+          return;
+        }
+
+        /* FFmpeg output */
+        while (fgets(buffer.data(), buffer.size(), pipe) != nullptr) {
+          result += buffer.data();
+        }
+
+        std::cout << result << std::endl;
+        /* FFmpeg output */
+
+        /* FFmpeg pipeline/execution ended */
+        if (pclose(pipe) != 0) {
+          /* FFmpeg app fail : returns the exit status of FFmpeg app itself */
+          responder_.Finish(response_,
+                            Status(grpc::UNKNOWN, FFMPEG_COMMAND_FAIL_STATUS,
+                                   FFMPEG_COMMAND_FAIL_MSG),
+                            this);
+
+          status_ = FINISH;
+          return;
+          /* FFmpeg app fail : returns the exit status of FFmpeg app itself */
+        }
+        /* FFmpeg pipeline/execution ended */
+
+        /* FFmpeg successfully executed the commands */
+        responder_.Finish(
+            response_,
+            Status(grpc::OK, FFMPEG_EXEC_OK_STATUS, FFMPEG_EXEC_OK_MSG), this);
+
+        status_ = FINISH;
+        return;
+      } /* FFmpeg command processing ends */
+      else {
+        // Once in the FINISH state, deallocate ourselves (CallData).
+        delete this;
+      }
+    }
+
+  private:
+    CmdPass::AsyncService *service_;
+    grpc::ServerCompletionQueue *cq_;
+    grpc::ServerContext ctx_;
+    ReqCmds request_;
+    FFmpegServiceRes response_;
+    grpc::ServerAsyncResponseWriter<FFmpegServiceRes> responder_;
+    enum CallStatus { CREATE, PROCESS, FINISH };
+    CallStatus status_;
+  };
+
+  void HandleRpcs() {
+    new CallData(&service_, cq_.get());
+
+    void *tag;
+    bool ok;
+    while (true) {
+      cq_->Next(&tag, &ok);
+
+      if (ok) {
+        /*
+         * calling cq_->Shutdown will render "ok" to be false
+         * hence we should terminate the main loop
+         */
+        static_cast<CallData *>(tag)->Proceed();
+      } else
+        break;
+    }
+  }
+
+  std::unique_ptr<ServerCompletionQueue> cq_;
+  CmdPass::AsyncService service_;
+  std::unique_ptr<Server> server_;
+};
+
+CmdPassImpl manager;
+
+void wrapperSignalHandler(int signal) {
+  std::cout << "[*] wrapperSignalHandler called SIG : " << signal << std::endl;
+  manager.Shutdown();
+}
+
+int main(int argc, char *argv[]) {
+  if (argc != 3) {
+    std::cout
+        << "[*] FFmpeg wrapper service takes 2 arguments: interface and port"
+        << std::endl;
+    return 1;
+  }
+
+  std::stringstream ss;
+  ss << argv[1] << ":" << argv[2];
+
+  std::signal(SIGTERM, wrapperSignalHandler);
+  std::signal(SIGINT, wrapperSignalHandler);
+
+  manager.Run(ss.str());
+
+  std::cout << "[*] Service exited gracefully" << std::endl;
+
+  return 0;
+}

--- a/gRPC/README.md
+++ b/gRPC/README.md
@@ -1,0 +1,76 @@
+# Overview
+The `FFmpeg_wrapper_service.cc` file implements a gRPC server that executes FFmpeg commands received from clients. The server handles requests asynchronously using a completion queue and processes each request in a separate instance of the CallData class.
+
+### Key Components : 
+
+**1. Includes and Using Declarations**:
+- Includes necessary headers for gRPC, standard I/O, and signal handling.
+- Uses gRPC classes and functions for server and request handling.
+
+**2. Constants**:
+
+- Defines constants for various FFmpeg command statuses and messages.
+
+**3. CmdPassImpl Class**:
+
+- Manages the server lifecycle and handles incoming RPC calls.
+
+**4. CallData Class**:
+
+-  Manages the lifecycle of an individual RPC call.
+- Processes the FFmpeg command and sends the response back to the client.
+
+**5. Signal Handling**:
+
+- Sets up signal handlers to gracefully shut down the server on receiving SIGTERM or SIGINT.
+
+**6. Main Function**:
+
+- Parses command-line arguments to get the server address and port.
+- Initializes and runs the server.
+
+### Detailed Explanation
+
+**1. CmdPassImpl Class**:
+
+Run Method:
+
+- Initializes the server with the provided address and port.
+- Registers the service and adds a completion queue.
+- Starts the server and prints a message indicating that the server is running.
+- Creates a thread to wait for the stop flag and shut down the server gracefully.
+- Calls HandleRpcs to start processing incoming RPC calls.
+
+Shutdown Method:
+
+- Sets the stop flag to true and notifies the waiting thread to shut down the server.
+
+**2. CallData Class**:
+
+Constructor:
+
+- Initializes the service, completion queue, responder, and status.
+- Calls Proceed to start processing the request.
+- Proceed Method:
+- Handles the different stages of the RPC call lifecycle (CREATE, PROCESS, FINISH).
+- In the CREATE stage, requests the next FFmpeg command execution.
+- In the PROCESS stage, constructs the FFmpeg command from the request and executes it using popen.
+- Captures the output of the FFmpeg command and prints it.
+- Sends the appropriate response based on the success or failure of the command execution.
+- In the FINISH stage, deletes the CallData instance.
+
+**3. HandleRpcs Method**:
+
+- Creates a new CallData instance to handle incoming requests.
+- Continuously processes incoming requests from the completion queue until the server is shut down.
+
+**4. Signal Handling**:
+
+- Sets up signal handlers to call Shutdown on receiving SIGTERM or SIGINT.
+
+**5. Main Function** :
+
+- Parses command-line arguments to get the server address and port.
+- Initializes a CmdPassImpl instance and sets the global pointer.
+- Sets up signal handlers.
+- Calls Run to start the server.

--- a/gRPC/README.md
+++ b/gRPC/README.md
@@ -74,3 +74,75 @@ Constructor:
 - Initializes a CmdPassImpl instance and sets the global pointer.
 - Sets up signal handlers.
 - Calls Run to start the server.
+
+--------------------------------------------------------------------------------------------------------------------
+
+The `FFmpeg_wrapper_client.cc` file implements a gRPC client that sends FFmpeg commands to a gRPC server and handles the responses asynchronously. The client is designed to manage multiple requests concurrently and ensures that all requests are completed before shutting down.
+
+### Key Components
+**1. Includes and Using Declarations**:
+
+- Includes necessary headers for gRPC, standard I/O, and string manipulation.
+- Includes the generated protobuf headers for FFmpeg command wrapping.
+
+**2. CmdPassClient Class**:
+
+- Manages the client lifecycle and handles sending FFmpeg commands to the server.
+- Contains methods for initiating and processing asynchronous RPC calls.
+
+**3. Constructor**:
+
+- Initializes the gRPC channel and stub for communication with the server.
+- Starts a thread to process the completion queue for handling asynchronous responses.
+
+**4. Destructor**:
+
+- Shuts down the completion queue and joins the processing thread to ensure a clean shutdown.
+
+**5. FFmpegCmdExec Method**:
+
+- Constructs the request object from a vector of command pairs.
+- Initiates an asynchronous RPC call to the server.
+- Increments the count of pending requests.
+
+**6. AsyncCompleteRpc Method**:
+
+- Continuously processes responses from the completion queue.
+- Handles successful and failed RPC calls by printing appropriate messages.
+- Decrements the count of pending requests and notifies if all requests are completed.
+
+**7. WaitForAllRequests Method**:
+
+- Waits for all pending requests to be completed before proceeding.
+
+### Detailed Explanation
+
+**1. CmdPassClient Class**:
+
+- Takes the server interface and port as arguments.
+- Creates a gRPC channel and stub for communication with the server.
+- Starts a thread to process the completion queue for handling asynchronous responses.
+- Destructor:
+- Shuts down the completion queue to stop processing responses.
+- Joins the processing thread to ensure it has completed before the client is destroyed.
+
+**2. FFmpegCmdExec Method**:
+
+- Takes a vector of command pairs as input.
+- Constructs a ReqCmds request object and populates it with the command pairs.
+- Creates a new AsyncClientCall object to manage the asynchronous RPC call.
+- Increments the count of pending requests.
+- Initiates the asynchronous RPC call and sets up the response reader to handle the response.
+
+**3. AsyncCompleteRpc Method**:
+
+- Runs in a separate thread to process responses from the completion queue.
+- Continuously waits for responses and processes them as they arrive.
+- Handles successful responses by printing a success message.
+- Handles failed responses by printing error details.
+- Decrements the count of pending requests and notifies if all requests are completed.
+
+**4. WaitForAllRequests Method**:
+
+- Uses a condition variable to wait until all pending requests are completed.
+- Ensures that the client does not shut down until all requests have been processed.

--- a/gRPC/cmd_pass_client.cc
+++ b/gRPC/cmd_pass_client.cc
@@ -1,0 +1,36 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2024 Intel Corporation
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include "FFmpeg_wrapper_client.h"
+#include <utility>
+#include <vector>
+
+int main(int argc, char* argv[]) {
+
+    if(argc != 3) {
+        std::cout << "client sample app only takes two argument 1) interface 2) port" << std::endl;
+        return 1;
+    }
+
+    std::vector<std::pair<std::string, std::string>> vec1 = {};
+    std::vector<std::pair<std::string, std::string>> vec2 = {{"key3", "val3"}, {"key4", "val4"}};
+    std::vector<std::pair<std::string, std::string>> vec3 = {{"key5", "val5"}, {"key6", "val6"}};
+
+    std::string interface = "localhost";
+    std::string port = "50051";
+
+    CmdPassClient obj(interface, port);
+
+    // Send multiple asynchronous requests
+    obj.FFmpegCmdExec(vec1);
+    obj.FFmpegCmdExec(vec2);
+    obj.FFmpegCmdExec(vec3);
+
+    // Wait for all asynchronous operations to complete
+    obj.WaitForAllRequests();
+
+    return 0;
+}

--- a/gRPC/compile.sh
+++ b/gRPC/compile.sh
@@ -1,8 +1,8 @@
+#!/bin/bash
+
 #SPDX-FileCopyrightText: Copyright (c) 2024 Intel Corporation
 #
 #SPDX-License-Identifier: BSD-3-Clause
-
-#!/bin/bash
 
 cmake -S . -B build && cd build && make && cd ..
 

--- a/gRPC/compile.sh
+++ b/gRPC/compile.sh
@@ -1,0 +1,8 @@
+#SPDX-FileCopyrightText: Copyright (c) 2024 Intel Corporation
+#
+#SPDX-License-Identifier: BSD-3-Clause
+
+#!/bin/bash
+
+cmake -S . -B build && cd build && make && cd ..
+

--- a/gRPC/ffmpeg_cmd_wrap.proto
+++ b/gRPC/ffmpeg_cmd_wrap.proto
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2024 Intel Corporation
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+syntax = "proto3";
+
+message CmdMsg {
+  string cmd_key = 1;
+  string cmd_val = 2;
+}
+
+message ReqCmds {
+  repeated CmdMsg obj = 1;
+}
+
+message FFmpegServiceRes {
+  int32 status = 1;
+  string message = 2;
+}
+
+service CmdPass {
+  rpc FFmpegCmdExec(ReqCmds) returns (FFmpegServiceRes) {}
+}


### PR DESCRIPTION
### gRPC service and client POC to support NMOS - FFmpeg comms :

**Build :**  `cd <BCS_folder>/gRPC/ && ./compile.sh`

new folder `build` will be created and contains:
1. `FFmpeg_wrapper_service` : service application which invokes FFmpeg application using system call.
2. `libFFmpeg_wrapper_client.a` : client "static" library which implements interface to send command pair(s) and receive back return int value.
3. `cmd_pass_client` : very simple application to link and send "dummy" command pairs.
4. gRPC abstraction files to be used in compile time by service and client implementation, these files are generated by protoc C++ plugin using the interface and message structure defined in `ffmpeg-cmd-wrap.proto`
 
**Configuration :**
service application is expecting 1) FFmpeg and gRPC to be already installed on the application pod - to be confirmed. 2) on launching, two parameters are representing interface and port are needed. this applies as well in case of bare metal.

client module are just exposing an obj which takes the interface and port on construction passed by user application on run-time. 

NOTE : channel setup for now is the same for bare metal and on container, so layer of pods comms config isn't managed by service or client for now, this is subject to change.

**Execution :**
Client side : after NMOS client link and load `libFFmpeg_wrapper_client.a` first need to setup a channel i.e `CmdPassClient obj(interface, port)` and later for each time a group of commands needs to be executed together, these commands needs to be organized in vector of {key,value} pairs i.e `std::vector<std::pair<std::string, std::string>> vec = {{"key1", "val1"}, {"key2", "val2"}};` and then execute these commands using the already initiated object i.e `obj.ffpmeg_cmd_exec(vec)`.

note : you need only the key and value of command, please DON'T use dashes before command key. i.e `-fps 25` would be a pair `{fps,25}`.

Service side : the service is initiated with interface and port to read incoming commands and execute them using `std::system` so at the end the commands sent will be executed as `ffpmeg -key1 val1 -key2 val2 ... -keyn valn`.