### PR TITLE
Add parameters support for nmos and ffmpeg

### DIFF
--- a/nmos/patches/nmos-cpp.patch
+++ b/nmos/patches/nmos-cpp.patch
@@ -354,7 +354,7 @@ index e4b420f..f09cdc0 100644
  
          slog::log<slog::severities::info>(gate, SLOG_FLF) << "Preparing for connections";
 diff --git a/Development/nmos-cpp-node/node_implementation.cpp b/Development/nmos-cpp-node/node_implementation.cpp
-index f12cca1..c0b25cb 100644
+index f12cca1..b5e476a 100644
 --- a/Development/nmos-cpp-node/node_implementation.cpp
 +++ b/Development/nmos-cpp-node/node_implementation.cpp
 @@ -1,3 +1,7 @@
@@ -1266,7 +1266,7 @@ index f12cca1..c0b25cb 100644
 -    const auto how_many = impl::fields::how_many(model.settings);
 -    const auto sender_ports = impl::parse_ports(impl::fields::senders(model.settings));
 -    const auto ws_sender_ports = boost::copy_range<std::vector<impl::port>>(sender_ports | boost::adaptors::filtered(impl::is_ws_port));
--
+ 
 -    // start background tasks to intermittently update the state of the event sources, to cause events to be emitted to connected receivers
 -
 -    nmos::details::seed_generator events_seeder;
@@ -1323,7 +1323,7 @@ index f12cca1..c0b25cb 100644
 -            {
 -                const auto temperature_sensor_control_class_id = nmos::make_nc_class_id(nmos::nc_worker_class_id, 0, { 3 });
 -                const web::json::field_as_number temperature{ U("temperature") };
- 
+-
 -                auto& resources = model.control_protocol_resources;
 -
 -                auto found = nmos::find_resource_if(resources, nmos::types::nc_worker, [&temperature_sensor_control_class_id](const nmos::resource& resource)
@@ -1513,7 +1513,7 @@ index f12cca1..c0b25cb 100644
  nmos::connection_activation_handler make_node_implementation_connection_activation_handler(nmos::node_model& model, slog::base_gate& gate)
  {
      auto handle_load_ca_certificates = nmos::make_load_ca_certificates_handler(model.settings, gate);
-@@ -1666,14 +988,112 @@ nmos::connection_activation_handler make_node_implementation_connection_activati
+@@ -1666,14 +988,173 @@ nmos::connection_activation_handler make_node_implementation_connection_activati
      auto connection_events_activation_handler = nmos::make_connection_events_websocket_activation_handler(handle_load_ca_certificates, handle_events_ws_message, handle_close, model.settings, gate);
      // this example uses this callback to update IS-12 Receiver-Monitor connection status
      auto receiver_monitor_connection_activation_handler = nmos::make_receiver_monitor_connection_activation_handler(model.control_protocol_resources);
@@ -1523,9 +1523,16 @@ index f12cca1..c0b25cb 100644
      {
          const std::pair<nmos::id, nmos::type> id_type{ resource.id, resource.type };
 -        slog::log<slog::severities::info>(gate, SLOG_FLF) << nmos::stash_category(impl::categories::node_implementation) << "Activating " << id_type;
--
 +        if(id_type.second == nmos::types::sender)
 +        {
+ 
+-        connection_events_activation_handler(resource, connection_resource);
++            slog::log<slog::severities::info>(gate, SLOG_FLF) << nmos::stash_category(impl::categories::node_implementation) << "this is "<< id_type << "---> send json for sender";
++            auto data = connection_resource.data;
++            auto sender_source_ip = data[nmos::fields::endpoint_active][nmos::fields::transport_params][0][nmos::fields::source_ip];
++            auto receiver_destination_ip = data[nmos::fields::endpoint_active][nmos::fields::transport_params][0][nmos::fields::destination_ip];
++            auto receiver_destination_port = data[nmos::fields::endpoint_active][nmos::fields::transport_params][0][nmos::fields::destination_port];
++
 +            FrameRate framerate;
 +            auto fr = impl::fields::frame_rate(model.settings);
 +            framerate.numerator = nmos::fields::numerator(fr);
@@ -1540,24 +1547,51 @@ index f12cca1..c0b25cb 100644
 +            File file;
 +            file.path=impl::fields::sender_input_path(model.settings);
 +            file.filename=impl::fields::sender_input_path_name(model.settings);
-+            // payload_type current_payload = video;
++            Payload payload = {
++                payload_type::video,
++                v,
++                audio
++            };
++            ST2110 st2110 = {};
++            // ST2110 st2110 = {
++            //     "0000:00:00.0", // network_interface TODO
++            //     sender_source_ip, // local_ip
++            //     receiver_destination_ip, // remote_ip
++            //     "udp", // transport
++            //     receiver_destination_port, // remote_port
++            //     impl::fields::sender_payload_type(model.settings) // payload_type
++            // };
++            MCM mcm = {};
++            // MCM mcm = {
++            //     "tcp", // conn_type
++            //     "rtp", // transport
++            //     impl::fields::sender_pixel_format(model.settings), // transport_pixel_format
++            //     receiver_destination_ip, // ip
++            //     receiver_destination_port, // port
++            //     "urn:example:service" // urn
++            // };
 +
-+            // Payload payload;
-+            // payload.type=current_payload;
-+            // payload.video=video;
-+            // payload.audio=audio;
-+            Config conf;
-+            conf.function="multiviewer";
-+            conf.gpu_hw_acceleration="intel";
-+            conf.logging_level=0;
++             StreamType streamType = {
++                stream_type::file, //can be changed
++                file,
++                st2110,
++                mcm
++            };
++
++            Stream stream = {
++                payload, // payload
++                streamType // stream_type
++            };
++
++            Config config = {
++                {stream}, // senders
++                {stream}, // receivers - mock - TODO
++                "multiviewer", // function
++                "intel", // gpu_hw_acceleration
++                0 // logging_level
++            };
 +            
-+
-+            slog::log<slog::severities::info>(gate, SLOG_FLF) << nmos::stash_category(impl::categories::node_implementation) << "this is "<< id_type << "---> send json for sender";
-+            auto data = connection_resource.data;
-+            auto sender_source_ip = data[nmos::fields::endpoint_active][nmos::fields::transport_params][0][nmos::fields::source_ip];
-+            auto receiver_destination_ip = data[nmos::fields::endpoint_active][nmos::fields::transport_params][0][nmos::fields::destination_ip];
-+            auto receiver_destination_port = data[nmos::fields::endpoint_active][nmos::fields::transport_params][0][nmos::fields::destination_port];
-+
++            
 +            slog::log<slog::severities::info>(gate, SLOG_FLF) << nmos::stash_category(impl::categories::node_implementation) << "|| Send data: " <<
 +            " source_ip=" << sender_source_ip << "  " <<
 +            " destination_ip=" << receiver_destination_ip << "  " <<
@@ -1580,6 +1614,13 @@ index f12cca1..c0b25cb 100644
 +        }
 +        if(id_type.second == nmos::types::receiver)
 +        {
+ 
++            // Name of the environment variable you want to read
++             const char* vfio_port = "VFIO_PORT_T";
++
++            // Get the value of the environment variable
++            const char* vfio_port_value = std::getenv(vfio_port);
++
 +            slog::log<slog::severities::info>(gate, SLOG_FLF) << nmos::stash_category(impl::categories::node_implementation)<<"send sdp of sender for receiver";
 +            auto data = connection_resource.data;
 +            auto receiver_source_ip = data[nmos::fields::endpoint_active][nmos::fields::transport_params][0][nmos::fields::source_ip];
@@ -1624,14 +1665,33 @@ index f12cca1..c0b25cb 100644
 +            " trasportfile_sdp:: depth=" <<sdp::fields::value(*depth).as_string()<< " " <<
 +            " trasportfile_sdp:: ssn=" <<sdp::fields::value(*ssn).as_string()<< " " <<
 +            "";
++
++            // frameRate is unsafe ad unstable, only for dev version
++            FrameRate frameRate = {std::stoi(sdp::fields::value(*fps).as_string()), 1};
++            Video video = {std::stoi(sdp::fields::value(*width_param).as_string()), std::stoi(sdp::fields::value(*height_param).as_string()), frameRate, "yuv420p", encoding_name};
++            Audio audio = {};
++            File fileSender = {"/path/to/file", "1280x720_422p10le.yuv"};
++            
++            auto source_filter = sdp::find_name(attributes, sdp::attributes::source_filter);
++            auto destination_addr=sdp::fields::destination_address(sdp::fields::value(*source_filter));
++            ST2110 st2110 = {vfio_port_value, receiver_source_ip.as_string(), destination_addr, "udp", sdp::fields::port(media), payload_type};
++            MCM mcm = {};
++            Payload payload = {payload_type::video, video, audio};
++            StreamType streamTypeSaving = {stream_type::file, fileSender, st2110, mcm};
++            StreamType streamTypeR = {stream_type::st2110, fileSender, st2110, mcm};
++
++            Stream streamSaving = {payload, streamTypeSaving};
++            Stream stream = {payload, streamTypeR};
++
++            Config configSaving = {{streamSaving}, {stream}, "multiviewer", "intel", 0};
++
 +            grpc::sendDataToFfmpeg(impl::fields::ffmpeg_grpc_server_address(model.settings), impl::fields::ffmpeg_grpc_server_port(model.settings), data[nmos::fields::endpoint_active][nmos::fields::transport_params][0][nmos::fields::source_ip].as_string(), data[nmos::fields::endpoint_active][nmos::fields::transport_params][0][nmos::fields::destination_port].as_integer());
 +        }       
-         connection_events_activation_handler(resource, connection_resource);
--
++        connection_events_activation_handler(resource, connection_resource);
          receiver_monitor_connection_activation_handler(connection_resource);
      };
  }
-@@ -1752,6 +1172,15 @@ namespace impl
+@@ -1752,6 +1233,15 @@ namespace impl
          }));
      }
  
@@ -1647,7 +1707,7 @@ index f12cca1..c0b25cb 100644
      // find interface with the specified address
      std::vector<web::hosts::experimental::host_interface>::const_iterator find_interface(const std::vector<web::hosts::experimental::host_interface>& interfaces, const utility::string_t& address)
      {
-@@ -1861,12 +1290,11 @@ nmos::experimental::node_implementation make_node_implementation(nmos::node_mode
+@@ -1861,12 +1351,11 @@ nmos::experimental::node_implementation make_node_implementation(nmos::node_mode
          .on_load_ca_certificates(nmos::make_load_ca_certificates_handler(model.settings, gate))
          .on_system_changed(make_node_implementation_system_global_handler(model, gate)) // may be omitted if not required
          .on_registration_changed(make_node_implementation_registration_handler(gate)) // may be omitted if not required

--- a/nmos/patches/nmos-cpp.patch
+++ b/nmos/patches/nmos-cpp.patch
@@ -31,6 +31,196 @@ index f7e5216..bb9b6b8 100644
      // frame_rate: controls the grain_rate of video, audio and ancillary data sources and flows
      // and the equivalent parameter constraint on video receivers
      // the value must be an object like { "numerator": 25, "denominator": 1 }
+diff --git a/Development/nmos-cpp-node/ffmpeg_communication/ffmpeg_communication.hpp b/Development/nmos-cpp-node/ffmpeg_communication/ffmpeg_communication.hpp
+new file mode 100644
+index 0000000..5b05611
+--- /dev/null
++++ b/Development/nmos-cpp-node/ffmpeg_communication/ffmpeg_communication.hpp
+@@ -0,0 +1,90 @@
++#ifndef FFMPEG_COMMUNICATION_HPP
++#define FFMPEG_COMMUNICATION_HPP
++#include <string>
++#include <vector>
++#include <map>
++
++struct FrameRate {
++    int numerator;
++    int denominator;
++};
++ 
++struct Video {
++    int frame_width;
++    int frame_height;
++    FrameRate frame_rate;
++    std::string pixel_format;
++    std::string video_type; 
++    // in case of rawvideo then ffmpeg param = "-f rawvideo"
++    // otherwise -c:v <video_type> e.g. -c:v x264
++};
++ 
++ // Audio struct is a placeholder for future implementation
++struct Audio {
++    int channels;
++    int sample_rate;
++    std::string format;
++    std::string packet_time;
++};
++ 
++struct File {
++    std::string path;
++    std::string filename;
++};
++ 
++struct ST2110 {
++    std::string network_interface; //VFIO port address 0000:00:00.0; ffmpeg param name: -p_port
++    std::string local_ip; // ffmpeg param name: -p_sip
++    std::string remote_ip; // ffmpeg param name: -p_rx_ip / -p_tx_ip
++    std::string transport; 
++    int remote_port; // ffmpeg param name: -udp_port
++    int payload_type;
++};
++ 
++struct MCM {
++    std::string conn_type;
++    std::string transport;
++    std::string transport_pixel_format;
++    std::string ip;
++    int port;
++    std::string urn;
++};
++ 
++enum payload_type {
++    video = 0,
++    audio
++ };
++
++struct Payload {
++    payload_type type;
++    Video video;
++    Audio audio;
++};
++ 
++enum stream_type {
++    file = 0,
++    st2110,
++    mcm
++ };
++
++struct StreamType {
++    stream_type type; 
++    File file;
++    ST2110 st2110;
++    MCM mcm;
++};
++ 
++struct Stream {
++    Payload payload;
++    StreamType stream_type;
++};
++ 
++struct Config {
++    std::vector<Stream> senders;
++    std::vector<Stream> receivers;
++
++    std::string function; //multiviewer, upscale, replay, recorder, jpegxs, rx, tx
++    std::string gpu_hw_acceleration; //intel, nvidia, none
++    int logging_level;
++};
++#endif
+diff --git a/Development/nmos-cpp-node/intel-node.json b/Development/nmos-cpp-node/intel-node.json
+new file mode 100644
+index 0000000..a453cc6
+--- /dev/null
++++ b/Development/nmos-cpp-node/intel-node.json
+@@ -0,0 +1,87 @@
++{
++    "logging_level": 0,
++    "http_port": 84,
++    "label": "intel-broadcast-suite",
++    "senders": ["v"],
++    "senders_count": [1],
++    "receivers": ["v"],
++    "receivers_count": [1],
++    "device_tags": {
++        "pipeline": ["multiviewer"]
++    },
++    "function" : "multiviewer", | upscale | replay | recorder | jpegxs |tx | rx
++    "gpu_hw_acceleration": "intel", | nvidia | none
++    "domain": "local",
++    "ffmpeg_grpc_server_address": "<ip_of_ffmpeg_grpc_server>",
++    "ffmpeg_grpc_server_port": "50051",
++    "sender":
++    [{
++      "payload":
++      {
++        "video" : {
++          "frame_width" : 1920,
++          "frame_height" : 1080,
++          "frame_rate": { "numerator": 60, "denominator": 1 },
++          "pixel_format": "yuv422p10le",
++          "video_type": "rawvideo"
++        },
++        "audio" : {
++          "channels" : 2,
++          "sampleRate" : 48000,
++          "format" : "pcm_s24be",
++          "packetTime" : "1ms"
++        }
++      },
++      "stream_type": {
++        "file" : {
++          "path" : "/path/to/input",
++          "filename" : "1280x720_422p10le.yuv"
++        },
++        "st2110" : {
++          "transport" : "st2110-20",
++          "payloadType" : 112
++        },
++        "mcm": {
++          "conn_type": "st2110",
++          "transport": "st2110-20",
++          "urn": "NULL",
++          "transportPixelFormat": "yuv422p10rfc4175"
++        }
++      }
++    }],
++    "receiver":
++    [{
++      "payload":
++      {
++        "video" : {
++          "frame_width" : 1920,
++          "frame_height" : 1080,
++          "frame_rate": { "numerator": 60, "denominator": 1 },
++          "pixel_format": "yuv422p10le",
++          "video_type": "rawvideo"
++        },
++        "audio" : {
++          "channels" : 2,
++          "sampleRate" : 48000,
++          "format" : "pcm_s24be",
++          "packetTime" : "1ms"
++        }
++      },
++      "stream_type": {
++        "file" : {
++          "path" : "/path/to/input",
++          "filename" : "1280x720_422p10le.yuv"
++        },
++        "st2110" : {
++          "transport" : "st2110-20",
++          "payloadType" : 112
++        },
++        "mcm": {
++          "conn_type": "st2110",
++          "transport": "st2110-20",
++          "urn": "NULL",
++          "transportPixelFormat": "yuv422p10rfc4175"
++        }
++      }
++    }]
++  }
+\ No newline at end of file
 diff --git a/Development/nmos-cpp-node/main.cpp b/Development/nmos-cpp-node/main.cpp
 index e4b420f..f09cdc0 100644
 --- a/Development/nmos-cpp-node/main.cpp
@@ -164,25 +354,28 @@ index e4b420f..f09cdc0 100644
  
          slog::log<slog::severities::info>(gate, SLOG_FLF) << "Preparing for connections";
 diff --git a/Development/nmos-cpp-node/node_implementation.cpp b/Development/nmos-cpp-node/node_implementation.cpp
-index f12cca1..30ff23a 100644
+index f12cca1..c0b25cb 100644
 --- a/Development/nmos-cpp-node/node_implementation.cpp
 +++ b/Development/nmos-cpp-node/node_implementation.cpp
-@@ -1,3 +1,6 @@
+@@ -1,3 +1,7 @@
 +#include <iostream>
 +#include <cstdlib>
++
 +
  #include "node_implementation.h"
  
  #include <boost/range/adaptor/filtered.hpp>
-@@ -49,6 +52,16 @@
+@@ -49,6 +53,18 @@
  #include "nmos/video_jxsv.h"
  #include "sdp/sdp.h"
  
-+namespace grpc{
++#include "ffmpeg_communication/ffmpeg_communication.hpp"
++
++namespace grpc {
 +// Function to execute the grpc client logic for ffmpeg
-+int sendDataToFfmpeg(const std::string& interface, const std::string& port, const std::string& source_ip, const std::string& destination_port ) {
-+    std::string command = "./gRPC/build/cmd_pass_client";
-+    std::string result = command+" "+interface+" "+port+" "+ source_ip+" "+destination_port;
++int sendDataToFfmpeg(const std::string& interface, const std::string& port, const std::string& source_ip, int destination_port) {
++    std::string command = "../../../../gRPC/build/cmd_pass_client";
++    std::string result = command + " " + interface + " " + port + " " + source_ip + " " + std::to_string(destination_port);
 +    const char* concatenated = result.c_str();
 +    return system(concatenated);
 +}
@@ -191,7 +384,7 @@ index f12cca1..30ff23a 100644
  // example node implementation details
  namespace impl
  {
-@@ -71,9 +84,6 @@ namespace impl
+@@ -71,9 +87,6 @@ namespace impl
          const web::json::field_as_value_or node_tags{ U("node_tags"), web::json::value::object() };
          const web::json::field_as_value_or device_tags{ U("device_tags"), web::json::value::object() };
  
@@ -201,7 +394,7 @@ index f12cca1..30ff23a 100644
          // activate_senders: controls whether to activate senders on start up (true, default) or not (false)
          const web::json::field_as_bool_or activate_senders{ U("activate_senders"), true };
  
-@@ -83,6 +93,17 @@ namespace impl
+@@ -83,6 +96,32 @@ namespace impl
          const web::json::field_as_value_or senders{ U("senders"), {} };
          const web::json::field_as_value_or receivers{ U("receivers"), {} };
  
@@ -211,15 +404,30 @@ index f12cca1..30ff23a 100644
 +        const web::json::field_as_value_or senders_count{ U("senders_count"), {} };
 +        const web::json::field_as_value_or receivers_count{ U("receivers_count"), {} };
 +
++        const web::json::field_as_string_or sender_input_path{ U("sender_input_path"), "" };
++        const web::json::field_as_string_or sender_input_path_name{ U("sender_input_path_name"), ""};
++
++        const web::json::field_as_string_or sender_ffmpeg_video_type{ U("sender_ffmpeg_video_type"), "" };
++        const web::json::field_as_string_or sender_pixel_format{ U("sender_pixel_format"), "" };
++        const web::json::field_as_string_or sender_transportFormat{ U("sender_transportFormat"), "" };
++        const web::json::field_as_string_or sender_conn_type{ U("sender_conn_type"), "" };
++        const web::json::field_as_string_or sender_transport{ U("sender_transport"), "" };
++        web::json::field_as_integer_or sender_payload_type{ U("sender_payload_type"), 96 };
++        
++
++        const web::json::field_as_string_or receiver_transportFormat{ U("receiver_transportFormat"), "" };
++        const web::json::field_as_string_or receiver_conn_type{ U("receiver_conn_type"), "" };
++        const web::json::field_as_string_or receiver_transport{ U("receiver_transport"), "" };
++
 +        // IP address and port to connect to ffmpeg grpc service in order to pass properties when another NMOS node
 +        // is connected to this NMOS node for BCS pipeline
-+        const web::json::field_as_string_or ffmpeg_grpc_server_address{ U("ffmpeg_grpc_server_address")};
-+        const web::json::field_as_string_or ffmpeg_grpc_server_port{ U("ffmpeg_grpc_server_port")};
++        const web::json::field_as_string_or ffmpeg_grpc_server_address{ U("ffmpeg_grpc_server_address"), "localhost"};
++        const web::json::field_as_string_or ffmpeg_grpc_server_port{ U("ffmpeg_grpc_server_port"), "50051"};
 +
          // frame_rate: controls the grain_rate of video, audio and ancillary data sources and flows
          // and the equivalent parameter constraint on video receivers
          // the value must be an object like { "numerator": 25, "denominator": 1 }
-@@ -155,6 +176,7 @@ namespace impl
+@@ -155,6 +194,7 @@ namespace impl
      bool is_rtp_port(const port& port);
      bool is_ws_port(const port& port);
      std::vector<port> parse_ports(const web::json::value& value);
@@ -227,7 +435,7 @@ index f12cca1..30ff23a 100644
  
      const std::vector<nmos::channel> channels_repeat{
          { U("Left Channel"), nmos::channel_symbols::L },
-@@ -193,8 +215,8 @@ namespace impl
+@@ -193,8 +233,8 @@ namespace impl
  // forward declarations for node_implementation_thread
  void node_implementation_init(nmos::node_model& model, nmos::experimental::control_protocol_state& control_protocol_state, slog::base_gate& gate);
  void node_implementation_run(nmos::node_model& model, slog::base_gate& gate);
@@ -238,13 +446,15 @@ index f12cca1..30ff23a 100644
  
  struct node_implementation_init_exception {};
  
-@@ -248,7 +270,12 @@ void node_implementation_init(nmos::node_model& model, nmos::experimental::contr
+@@ -248,7 +288,14 @@ void node_implementation_init(nmos::node_model& model, nmos::experimental::contr
      const auto seed_id = nmos::experimental::fields::seed_id(model.settings);
      const auto node_id = impl::make_id(seed_id, nmos::types::node);
      const auto device_id = impl::make_id(seed_id, nmos::types::device);
 -    const auto how_many = impl::fields::how_many(model.settings);
 +    const auto ffmpeg_grpc_server_address = impl::fields::ffmpeg_grpc_server_address(model.settings);
 +    const auto ffmpeg_grpc_server_port = impl::fields::ffmpeg_grpc_server_port(model.settings);
++    const auto sender_input_path = impl::fields::sender_input_path(model.settings);
++    const auto sender_input_path_name = impl::fields::sender_input_path_name(model.settings);
 +    const auto senders_count = impl::parse_count(impl::fields::senders_count(model.settings)); // max count of elements = 4 (because 4 types of ports: video, audio, mux, data)
 +    const auto senders_count_total = std::accumulate(senders_count.begin(), senders_count.end(), 0);
 +    const auto receivers_count = impl::parse_count(impl::fields::receivers_count(model.settings)); // max count of elements = 4 (because 4 types of ports: video, audio, mux, data)
@@ -252,7 +462,7 @@ index f12cca1..30ff23a 100644
      const auto sender_ports = impl::parse_ports(impl::fields::senders(model.settings));
      const auto rtp_sender_ports = boost::copy_range<std::vector<impl::port>>(sender_ports | boost::adaptors::filtered(impl::is_rtp_port));
      const auto ws_sender_ports = boost::copy_range<std::vector<impl::port>>(sender_ports | boost::adaptors::filtered(impl::is_ws_port));
-@@ -279,6 +306,15 @@ void node_implementation_init(nmos::node_model& model, nmos::experimental::contr
+@@ -279,6 +326,15 @@ void node_implementation_init(nmos::node_model& model, nmos::experimental::contr
      // any delay between updates to the model resources is unnecessary unless for debugging purposes
      const unsigned int delay_millis{ 0 };
  
@@ -268,7 +478,7 @@ index f12cca1..30ff23a 100644
      // it is important that the model be locked before inserting, updating or deleting a resource
      // and that the the node behaviour thread be notified after doing so
      const auto insert_resource_after = [&model, &lock](unsigned int milliseconds, nmos::resources& resources, nmos::resource&& resource, slog::base_gate& gate)
-@@ -293,7 +329,7 @@ void node_implementation_init(nmos::node_model& model, nmos::experimental::contr
+@@ -293,7 +349,7 @@ void node_implementation_init(nmos::node_model& model, nmos::experimental::contr
          else
              slog::log<slog::severities::severe>(gate, SLOG_FLF) << "Model update error: " << id_type;
  
@@ -277,7 +487,7 @@ index f12cca1..30ff23a 100644
          model.notify();
  
          return success;
-@@ -320,15 +356,14 @@ void node_implementation_init(nmos::node_model& model, nmos::experimental::contr
+@@ -320,15 +376,14 @@ void node_implementation_init(nmos::node_model& model, nmos::experimental::contr
          if (!insert_resource_after(milliseconds, resources, std::move(root), gate)) throw node_implementation_init_exception();
      };
  
@@ -295,7 +505,7 @@ index f12cca1..30ff23a 100644
      {
          auto node = nmos::make_node(node_id, clocks, nmos::make_node_interfaces(interfaces), model.settings);
          node.data[nmos::fields::tags] = impl::fields::node_tags(model.settings);
-@@ -370,20 +405,25 @@ void node_implementation_init(nmos::node_model& model, nmos::experimental::contr
+@@ -370,20 +425,25 @@ void node_implementation_init(nmos::node_model& model, nmos::experimental::contr
          ? std::vector<utility::string_t>{ primary_interface.name, secondary_interface.name }
          : std::vector<utility::string_t>{ primary_interface.name };
  
@@ -328,7 +538,28 @@ index f12cca1..30ff23a 100644
          {
              const auto source_id = impl::make_id(seed_id, nmos::types::source, port, index);
              const auto flow_id = impl::make_id(seed_id, nmos::types::flow, port, index);
-@@ -516,13 +556,15 @@ void node_implementation_init(nmos::node_model& model, nmos::experimental::contr
+@@ -393,6 +453,12 @@ void node_implementation_init(nmos::node_model& model, nmos::experimental::contr
+             if (impl::ports::video == port)
+             {
+                 source = nmos::make_video_source(source_id, device_id, nmos::clock_names::clk0, frame_rate, model.settings);
++                // If NMOS node is not working as RECEIVER, send to ffmpeg sender information about input path and filename
++                // TODO: extend for many senders in array. Use case only takes video type now! Be cautious!
++                if( receivers_count[senders_iterator] < 1) {
++                    // TODO add when ffmpeg is fixed: sendDataToFFmpeg
++                    slog::log<slog::severities::info>(gate, SLOG_FLF) << "sendDataToFFmpeg: sender_input_path=" << sender_input_path << "  sender_input_path_name=" <<sender_input_path_name;
++                }
+             }
+             else if (impl::ports::audio == port)
+             {
+@@ -481,6 +547,7 @@ void node_implementation_init(nmos::node_model& model, nmos::experimental::contr
+             // hm, could add nmos::make_video_jxsv_sender to encapsulate this?
+             if (impl::ports::video == port && nmos::media_types::video_jxsv == video_type)
+             {
++                
+                 // additional attributes required by BCP-006-01
+                 // see https://specs.amwa.tv/bcp-006-01/branches/v1.0-dev/docs/NMOS_With_JPEG_XS.html#senders
+                 const auto format_bit_rate = nmos::get_video_jxsv_bit_rate(frame_rate, frame_width, frame_height, bits_per_pixel);
+@@ -516,19 +583,24 @@ void node_implementation_init(nmos::node_model& model, nmos::experimental::contr
              if (!insert_resource_after(delay_millis, model.node_resources, std::move(sender), gate)) throw node_implementation_init_exception();
              if (!insert_resource_after(delay_millis, model.connection_resources, std::move(connection_sender), gate)) throw node_implementation_init_exception();
          }
@@ -349,7 +580,16 @@ index f12cca1..30ff23a 100644
              const auto receiver_id = impl::make_id(seed_id, nmos::types::receiver, port, index);
  
              nmos::resource receiver;
-@@ -626,774 +668,13 @@ void node_implementation_init(nmos::node_model& model, nmos::experimental::contr
+             if (impl::ports::video == port)
+             {
+                 receiver = nmos::make_receiver(receiver_id, device_id, nmos::transports::rtp, interface_names, nmos::formats::video, { video_type }, model.settings);
++                 // if receiver is created, nmos should send to ffmpeg information how many connactions the ffmpeg should wait
++                 // TODO add when ffmpeg is fixed: sendDataToFFmpeg
++                 slog::log<slog::severities::info>(gate, SLOG_FLF) << "sendDataToFfmpeg: ffmpeg should wait for connection of " << receivers_count[receivers_iterator] << " video receivers";
+                 // add an example constraint set; these should be completed fully!
+                 if (nmos::media_types::video_raw == video_type)
+                 {
+@@ -626,774 +698,13 @@ void node_implementation_init(nmos::node_model& model, nmos::experimental::contr
              if (!insert_resource_after(delay_millis, model.node_resources, std::move(receiver), gate)) throw node_implementation_init_exception();
              if (!insert_resource_after(delay_millis, model.connection_resources, std::move(connection_receiver), gate)) throw node_implementation_init_exception();
          }
@@ -1078,12 +1318,12 @@ index f12cca1..30ff23a 100644
 -                    });
 -                }
 -            }
- 
+-
 -            // update temperature sensor
 -            {
 -                const auto temperature_sensor_control_class_id = nmos::make_nc_class_id(nmos::nc_worker_class_id, 0, { 3 });
 -                const web::json::field_as_number temperature{ U("temperature") };
--
+ 
 -                auto& resources = model.control_protocol_resources;
 -
 -                auto found = nmos::find_resource_if(resources, nmos::types::nc_worker, [&temperature_sensor_control_class_id](const nmos::resource& resource)
@@ -1125,7 +1365,7 @@ index f12cca1..30ff23a 100644
  }
  
  // Example System API node behaviour callback to perform application-specific operations when the global configuration resource changes
-@@ -1438,14 +719,29 @@ nmos::registration_handler make_node_implementation_registration_handler(slog::b
+@@ -1438,15 +749,16 @@ nmos::registration_handler make_node_implementation_registration_handler(slog::b
  }
  
  // Example Connection API callback to parse "transport_file" during a PATCH /staged request
@@ -1138,26 +1378,13 @@ index f12cca1..30ff23a 100644
      return [](const nmos::resource& receiver, const nmos::resource& connection_receiver, const utility::string_t& transport_file_type, const utility::string_t& transport_file_data, slog::base_gate& gate)
      {
 -        const auto validate_sdp_parameters = [](const web::json::value& receiver, const nmos::sdp_parameters& sdp_params)
-+        // this is example implementation of retrieviening required params from transport file parameters
-+        // and send them to ffmpeg pipeline grpc server
-+        const auto session_description = sdp::parse_session_description(utility::us2s(transport_file_data));
-+        auto sdp_transport_params = nmos::parse_session_description(session_description);
-+        slog::log<slog::severities::info>(gate, SLOG_FLF) << nmos::stash_category(impl::categories::node_implementation)
-+        << sdp_transport_params.second[0][nmos::fields::source_ip];
-+        slog::log<slog::severities::info>(gate, SLOG_FLF) << nmos::stash_category(impl::categories::node_implementation)
-+        << sdp_transport_params.second[0][nmos::fields::destination_port];
-+        std::string source_ip = sdp_transport_params.second[0][nmos::fields::source_ip].as_string();
-+        std::string destination_port = sdp_transport_params.second[0][nmos::fields::destination_port].as_string();
-+        int result = grpc::sendDataToFfmpeg(impl::fields::ffmpeg_grpc_server_address, impl::fields::ffmpeg_grpc_server_port, source_ip, destination_port);
-+        if (result == -1) {
-+        slog::log<slog::severities::info>(gate, SLOG_FLF) << nmos::stash_category(impl::categories::node_implementation)
-+        << "Failed to execute command";
-+        }
 +        const auto validate_sdp_parameters = [&gate](const web::json::value& receiver, const nmos::sdp_parameters& sdp_params)
          {
++
              if (nmos::media_types::video_jxsv == nmos::get_media_type(sdp_params))
              {
-@@ -1462,7 +758,7 @@ nmos::transport_file_parser make_node_implementation_transport_file_parser()
+                 nmos::validate_video_jxsv_sdp_parameters(receiver, sdp_params);
+@@ -1462,7 +774,7 @@ nmos::transport_file_parser make_node_implementation_transport_file_parser()
  }
  
  // Example Connection API callback to perform application-specific validation of the merged /staged endpoint during a PATCH /staged request
@@ -1166,7 +1393,7 @@ index f12cca1..30ff23a 100644
  {
      // this example uses an 'empty' std::function because it does not need to do any validation
      // beyond what is expressed by the schemas and /constraints endpoint
-@@ -1470,26 +766,28 @@ nmos::details::connection_resource_patch_validator make_node_implementation_patc
+@@ -1470,26 +782,28 @@ nmos::details::connection_resource_patch_validator make_node_implementation_patc
  }
  
  // Example Connection API activation callback to resolve "auto" values when /staged is transitioned to /active
@@ -1203,7 +1430,7 @@ index f12cca1..30ff23a 100644
      {
          const std::pair<nmos::id, nmos::type> id_type{ connection_resource.id, connection_resource.type };
          // this code relies on the specific constraints added by node_implementation_thread
-@@ -1528,21 +826,24 @@ nmos::connection_resource_auto_resolver make_node_implementation_auto_resolver(c
+@@ -1528,21 +842,26 @@ nmos::connection_resource_auto_resolver make_node_implementation_auto_resolver(c
  }
  
  // Example Connection API activation callback to update senders' /transportfile endpoint - captures node_resources by reference!
@@ -1227,14 +1454,43 @@ index f12cca1..30ff23a 100644
 +    const auto rtp_source_ids = impl::make_ids(seed_id, nmos::types::source, rtp_sender_ports, senders_count_total);
 +    const auto rtp_flow_ids = impl::make_ids(seed_id, nmos::types::flow, rtp_sender_ports, senders_count_total);
 +    const auto rtp_sender_ids = impl::make_ids(seed_id, nmos::types::sender, rtp_sender_ports, senders_count_total);
++
++    const uint64_t payload_type_video = impl::fields::sender_payload_type(settings);
  
      // as part of activation, the example sender /transportfile should be updated based on the active transport parameters
 -    return [&node_resources, node_id, rtp_source_ids, rtp_flow_ids, rtp_sender_ids](const nmos::resource& sender, const nmos::resource& connection_sender, value& endpoint_transportfile)
-+    return [&node_resources, node_id, rtp_source_ids, rtp_flow_ids, rtp_sender_ids,  &gate](const nmos::resource& sender, const nmos::resource& connection_sender, value& endpoint_transportfile)
++    return [&node_resources, node_id, rtp_source_ids, rtp_flow_ids, rtp_sender_ids,payload_type_video,  &gate](const nmos::resource& sender, const nmos::resource& connection_sender, value& endpoint_transportfile)
      {
          const auto found = boost::range::find(rtp_sender_ids, connection_sender.id);
          if (rtp_sender_ids.end() != found)
-@@ -1621,10 +922,11 @@ nmos::connection_sender_transportfile_setter make_node_implementation_transportf
+@@ -1567,22 +886,24 @@ nmos::connection_sender_transportfile_setter make_node_implementation_transportf
+             // nmos::make_{video,audio,data,mux}_sdp_parameters provide a little more flexibility for those four media types
+             // and the combination of nmos::make_{video_raw,audio_L,video_smpte291,video_SMPTE2022_6}_parameters
+             // with the related make_sdp_parameters overloads provides the most flexible and extensible approach
++            
+             auto sdp_params = [&]
+             {
+                 const std::vector<utility::string_t> mids{ U("PRIMARY"), U("SECONDARY") };
+                 const nmos::format format{ nmos::fields::format(flow->data) };
++                
+                 if (nmos::formats::video == format)
+                 {
+                     const nmos::media_type video_type{ nmos::fields::media_type(flow->data) };
+                     if (nmos::media_types::video_raw == video_type)
+                     {
+-                        return nmos::make_video_sdp_parameters(node->data, source->data, flow->data, sender.data, nmos::details::payload_type_video_default, mids, {}, sdp::type_parameters::type_N);
++                        return nmos::make_video_sdp_parameters(node->data, source->data, flow->data, sender.data, payload_type_video, mids, {}, sdp::type_parameters::type_N);
+                     }
+                     else if (nmos::media_types::video_jxsv == video_type)
+                     {
+                         const auto params = nmos::make_video_jxsv_parameters(node->data, source->data, flow->data, sender.data);
+                         const auto ts_refclk = nmos::details::make_ts_refclk(node->data, source->data, sender.data, {});
+-                        return nmos::make_sdp_parameters(nmos::fields::label(sender.data), params, nmos::details::payload_type_video_default, mids, ts_refclk);
++                        return nmos::make_sdp_parameters(nmos::fields::label(sender.data), params, payload_type_video, mids, ts_refclk);
+                     }
+                     else
+                     {
+@@ -1621,10 +942,11 @@ nmos::connection_sender_transportfile_setter make_node_implementation_transportf
  nmos::events_ws_message_handler make_node_implementation_events_ws_message_handler(const nmos::node_model& model, slog::base_gate& gate)
  {
      const auto seed_id = nmos::experimental::fields::seed_id(model.settings);
@@ -1248,22 +1504,134 @@ index f12cca1..30ff23a 100644
  
      // the message handler will be used for all Events WebSocket connections, and each connection may potentially
      // have subscriptions to a number of sources, for multiple receivers, so this example uses a handler adaptor
-@@ -1666,14 +968,11 @@ nmos::connection_activation_handler make_node_implementation_connection_activati
+@@ -1654,7 +976,7 @@ nmos::events_ws_message_handler make_node_implementation_events_ws_message_handl
+     }, gate);
+ }
+ 
+-// Example Connection API activation callback to perform application-specific operations to complete activation
++// Connection API activation callback to perform application-specific operations to complete activation
+ nmos::connection_activation_handler make_node_implementation_connection_activation_handler(nmos::node_model& model, slog::base_gate& gate)
+ {
+     auto handle_load_ca_certificates = nmos::make_load_ca_certificates_handler(model.settings, gate);
+@@ -1666,14 +988,112 @@ nmos::connection_activation_handler make_node_implementation_connection_activati
      auto connection_events_activation_handler = nmos::make_connection_events_websocket_activation_handler(handle_load_ca_certificates, handle_events_ws_message, handle_close, model.settings, gate);
      // this example uses this callback to update IS-12 Receiver-Monitor connection status
      auto receiver_monitor_connection_activation_handler = nmos::make_receiver_monitor_connection_activation_handler(model.control_protocol_resources);
 -
-     return [connection_events_activation_handler, receiver_monitor_connection_activation_handler, &gate](const nmos::resource& resource, const nmos::resource& connection_resource)
+-    return [connection_events_activation_handler, receiver_monitor_connection_activation_handler, &gate](const nmos::resource& resource, const nmos::resource& connection_resource)
++    return [connection_events_activation_handler, receiver_monitor_connection_activation_handler, &model, &gate](const nmos::resource& resource, const nmos::resource& connection_resource)
      {
          const std::pair<nmos::id, nmos::type> id_type{ resource.id, resource.type };
-         slog::log<slog::severities::info>(gate, SLOG_FLF) << nmos::stash_category(impl::categories::node_implementation) << "Activating " << id_type;
+-        slog::log<slog::severities::info>(gate, SLOG_FLF) << nmos::stash_category(impl::categories::node_implementation) << "Activating " << id_type;
 -
++        if(id_type.second == nmos::types::sender)
++        {
++            FrameRate framerate;
++            auto fr = impl::fields::frame_rate(model.settings);
++            framerate.numerator = nmos::fields::numerator(fr);
++            framerate.denominator = nmos::fields::denominator(fr);
++            Video v;
++            v.frame_width=impl::fields::frame_width(model.settings);
++            v.frame_height=impl::fields::frame_height(model.settings);
++            v.frame_rate=framerate;
++            v.pixel_format=impl::fields::sender_pixel_format(model.settings);//default, todo
++            v.video_type=impl::fields::sender_ffmpeg_video_type(model.settings);
++            Audio audio = {};
++            File file;
++            file.path=impl::fields::sender_input_path(model.settings);
++            file.filename=impl::fields::sender_input_path_name(model.settings);
++            // payload_type current_payload = video;
++
++            // Payload payload;
++            // payload.type=current_payload;
++            // payload.video=video;
++            // payload.audio=audio;
++            Config conf;
++            conf.function="multiviewer";
++            conf.gpu_hw_acceleration="intel";
++            conf.logging_level=0;
++            
++
++            slog::log<slog::severities::info>(gate, SLOG_FLF) << nmos::stash_category(impl::categories::node_implementation) << "this is "<< id_type << "---> send json for sender";
++            auto data = connection_resource.data;
++            auto sender_source_ip = data[nmos::fields::endpoint_active][nmos::fields::transport_params][0][nmos::fields::source_ip];
++            auto receiver_destination_ip = data[nmos::fields::endpoint_active][nmos::fields::transport_params][0][nmos::fields::destination_ip];
++            auto receiver_destination_port = data[nmos::fields::endpoint_active][nmos::fields::transport_params][0][nmos::fields::destination_port];
++
++            slog::log<slog::severities::info>(gate, SLOG_FLF) << nmos::stash_category(impl::categories::node_implementation) << "|| Send data: " <<
++            " source_ip=" << sender_source_ip << "  " <<
++            " destination_ip=" << receiver_destination_ip << "  " <<
++            " destination_port=" << receiver_destination_port << "  " <<
++            " frame_rate="<<nmos::parse_rational(impl::fields::frame_rate(model.settings)) <<
++            " frame_width=" << impl::fields::frame_width(model.settings) << "  " <<
++            " frame_height=" << impl::fields::frame_height(model.settings) << "  " <<
++            " sender_payload_type="<< impl::fields::sender_payload_type(model.settings) << "  " <<
++            " sender_ffmpeg_video_type=" <<impl::fields::sender_ffmpeg_video_type(model.settings) << " " <<
++            " sender_pixel_format=" <<impl::fields::sender_pixel_format(model.settings) << " " <<
++            " sender_transportFormat=" <<impl::fields::sender_transportFormat(model.settings) << " " <<
++            " sender_conn_type=" <<impl::fields::sender_conn_type(model.settings) << " " <<
++            " sender_transport=" <<impl::fields::sender_transport(model.settings) << " " <<
++            " sender_input_path=" << impl::fields::sender_input_path(model.settings) << "  " <<
++            " sender_input_path_name=" << impl::fields::sender_input_path_name(model.settings) << "  " <<
++            ""; 
++
++            grpc::sendDataToFfmpeg(impl::fields::ffmpeg_grpc_server_address(model.settings), impl::fields::ffmpeg_grpc_server_port(model.settings), data[nmos::fields::endpoint_active][nmos::fields::transport_params][0][nmos::fields::source_ip].as_string(), data[nmos::fields::endpoint_active][nmos::fields::transport_params][0][nmos::fields::destination_port].as_integer());
++            
++        }
++        if(id_type.second == nmos::types::receiver)
++        {
++            slog::log<slog::severities::info>(gate, SLOG_FLF) << nmos::stash_category(impl::categories::node_implementation)<<"send sdp of sender for receiver";
++            auto data = connection_resource.data;
++            auto receiver_source_ip = data[nmos::fields::endpoint_active][nmos::fields::transport_params][0][nmos::fields::source_ip];
++            auto sender_destination_port = data[nmos::fields::endpoint_active][nmos::fields::transport_params][0][nmos::fields::destination_port];
++            auto trasportfile_sdp = data[nmos::fields::endpoint_active][nmos::fields::transport_file][nmos::fields::data];
++
++
++            auto session_description = sdp::parse_session_description(utility::us2s(trasportfile_sdp.as_string()));
++            auto& media_descriptions = sdp::fields::media_descriptions(session_description);
++            auto& media_description = media_descriptions.at(0);
++            auto& media = sdp::fields::media(media_description);
++            auto& attributes = sdp::fields::attributes(media_description).as_array();
++            auto rtpmap = sdp::find_name(attributes, sdp::attributes::rtpmap);
++
++            auto& encoding_name = sdp::fields::encoding_name(sdp::fields::value(*rtpmap));
++            const auto& payload_type = sdp::fields::payload_type(sdp::fields::value(*rtpmap));
++
++            auto fmtp = sdp::find_name(attributes, sdp::attributes::fmtp);
++
++            auto& params = sdp::fields::format_specific_parameters(sdp::fields::value(*fmtp));
++
++            auto width_param = sdp::find_name(params, U("width"));
++            auto height_param = sdp::find_name(params, U("height"));
++            auto fps = sdp::find_name(params, U("exactframerate"));
++            auto sampling = sdp::find_name(params, U("sampling"));
++            auto depth = sdp::find_name(params, U("depth"));
++            auto ssn = sdp::find_name(params, U("SSN"));
++            
++            slog::log<slog::severities::info>(gate, SLOG_FLF) << nmos::stash_category(impl::categories::node_implementation) << "|| Send data: " <<
++            " source_ip=" << receiver_source_ip << "  " <<
++            " destination_port=" << sender_destination_port << "  " <<
++            " receiver_transportFormat=" <<impl::fields::receiver_transportFormat(model.settings) << " " <<
++            " receiver_conn_type=" <<impl::fields::receiver_conn_type(model.settings) << " " <<
++            " receiver_transport=" <<impl::fields::receiver_transport(model.settings) << " " <<
++            " trasportfile_sdp:: media_type=" <<sdp::fields::media_type(media) << " " <<
++            " trasportfile_sdp:: encoding_name=" <<encoding_name<< " " <<
++            " trasportfile_sdp:: payload_type=" <<payload_type<< " " <<
++            " trasportfile_sdp:: width=" <<sdp::fields::value(*width_param).as_string()<< " " <<
++            " trasportfile_sdp:: height_param=" <<sdp::fields::value(*height_param).as_string()<< " " <<
++            " trasportfile_sdp:: fps=" <<sdp::fields::value(*fps).as_string()<< " " <<
++            " trasportfile_sdp:: sampling=" <<sdp::fields::value(*sampling).as_string()<< " " <<
++            " trasportfile_sdp:: depth=" <<sdp::fields::value(*depth).as_string()<< " " <<
++            " trasportfile_sdp:: ssn=" <<sdp::fields::value(*ssn).as_string()<< " " <<
++            "";
++            grpc::sendDataToFfmpeg(impl::fields::ffmpeg_grpc_server_address(model.settings), impl::fields::ffmpeg_grpc_server_port(model.settings), data[nmos::fields::endpoint_active][nmos::fields::transport_params][0][nmos::fields::source_ip].as_string(), data[nmos::fields::endpoint_active][nmos::fields::transport_params][0][nmos::fields::destination_port].as_integer());
++        }       
          connection_events_activation_handler(resource, connection_resource);
 -
          receiver_monitor_connection_activation_handler(connection_resource);
      };
  }
-@@ -1752,6 +1051,15 @@ namespace impl
+@@ -1752,6 +1172,15 @@ namespace impl
          }));
      }
  
@@ -1279,7 +1647,7 @@ index f12cca1..30ff23a 100644
      // find interface with the specified address
      std::vector<web::hosts::experimental::host_interface>::const_iterator find_interface(const std::vector<web::hosts::experimental::host_interface>& interfaces, const utility::string_t& address)
      {
-@@ -1861,12 +1169,11 @@ nmos::experimental::node_implementation make_node_implementation(nmos::node_mode
+@@ -1861,12 +1290,11 @@ nmos::experimental::node_implementation make_node_implementation(nmos::node_mode
          .on_load_ca_certificates(nmos::make_load_ca_certificates_handler(model.settings, gate))
          .on_system_changed(make_node_implementation_system_global_handler(model, gate)) // may be omitted if not required
          .on_registration_changed(make_node_implementation_registration_handler(gate)) // may be omitted if not required


### PR DESCRIPTION
Added support of parsing sdp file from sender to update receiver's properties of ffmpeg (when IS-05 connection occured)
Fixed data parsing for json and sdp
Added latest referral config of intel-node.json
Added unified Config struct that should be understandable by grpc service and ffmpeg
Changed from default payload to payload (that is set by 'user')

TO DO:
Refine Config struct to pass parameters
Change parsing of intel-node.json from nested struct
Add sender/receiver 'ffmpeg' support for nodes that container either only receivers or senders
Waiting for providing grpc interface
