### PR TITLE
Extend ffmpeg pipelie generator

### DIFF
--- a/gRPC/config_params.hpp
+++ b/gRPC/config_params.hpp
@@ -90,7 +90,11 @@ struct Config {
     std::vector<Stream> receivers;
 
     std::string function; //multiviewer, upscale, replay, recorder, jpegxs, rx, tx
+    int multiviewer_columns; //number of streams in a row
+
     std::string gpu_hw_acceleration; //intel, nvidia, none
+    std::string gpu_hw_acceleration_device; // /dev/dri/renderD128
+
     int logging_level;
 };
 

--- a/gRPC/config_serialize_deserialize.hpp
+++ b/gRPC/config_serialize_deserialize.hpp
@@ -15,7 +15,7 @@ NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(MCM, conn_type, transport, transport_pixel_fo
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(Payload, type, video, audio)
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(StreamType, type, file, st2110, mcm)
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(Stream, payload, stream_type)
-NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(Config, senders, receivers, function, gpu_hw_acceleration, logging_level)
+NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(Config, senders, receivers, function, multiviewer_columns, gpu_hw_acceleration, gpu_hw_acceleration_device, logging_level)
 
 //TODO: move serialize_config_json and deserialize_config_json to a separate file
 

--- a/gRPC/ffmpeg_pipeline_generator.cc
+++ b/gRPC/ffmpeg_pipeline_generator.cc
@@ -98,7 +98,7 @@ int ffmpeg_append_st2110_transport(std::string &transport, std::string &pipeline
         pipeline_string += " -f mtl_st30p";
     }
     else {
-        std::cout << "Error: transport " << transport << "not supported yet" << std::endl;
+        std::cout << "Error: transport " << transport << " not supported yet" << std::endl;
         return 1;
     }
     return 0;
@@ -266,7 +266,7 @@ int ffmpeg_generate_pipeline(Config &config, std::string &pipeline_string) {
         pipeline_string += " -y -hwaccel cuda -hwaccel_output_format cuda";
     }
     else {
-        std::cout << "Unsupported GPU acceleration" << config.gpu_hw_acceleration << std::endl;
+        std::cout << "Unsupported GPU acceleration " << config.gpu_hw_acceleration << std::endl;
         return 1;
     }
 

--- a/gRPC/unit_test/ffmpeg_pipeline_generator_test.cc
+++ b/gRPC/unit_test/ffmpeg_pipeline_generator_test.cc
@@ -161,6 +161,43 @@ void fill_conf_convert(Config &config) {
     }
 }
 
+void fill_conf_recorder(Config &config) {
+    config.function = "recorder";
+    config.gpu_hw_acceleration = "none";
+    config.logging_level = 0;
+
+    Payload p = get_video_payload_common();
+    {
+        Stream s;
+
+        s.payload = p;
+        s.stream_type.type = stream_type::file;
+        s.stream_type.file.path = "/videos";
+        s.stream_type.file.filename = "1920x1080p10le_1.yuv";
+        config.receivers.push_back(s);
+    }
+
+    {
+        Stream s;
+        s.payload = p;
+
+        s.payload.video.frame_width = 640;
+        s.payload.video.frame_height = 360;
+        s.stream_type.type = stream_type::file;
+        s.stream_type.file.path = "/videos/recv";
+        s.stream_type.file.filename = "recv_1.yuv";
+        config.senders.push_back(s);
+
+        s.payload.video.frame_width = 1280;
+        s.payload.video.frame_height = 720;
+        s.payload.video.video_type = "h263p";
+        s.stream_type.type = stream_type::file;
+        s.stream_type.file.path = "/videos/recv";
+        s.stream_type.file.filename = "recv_2.mov";
+        config.senders.push_back(s);
+    }
+}
+
 TEST(FFmpegPipelineGeneratorTest, test_sender) {
     Config conf;
     fill_conf_sender(conf);
@@ -240,5 +277,18 @@ TEST(FFmpegPipelineGeneratorTest, test_convert) {
             ASSERT_EQ(1, 0) << "Error generating convert pipeline" << std::endl;
     }
     std::string expected_string = " -y -video_size 1920x1080 -pix_fmt yuv422p10le -r 30/1 -f rawvideo -i /videos/1920x1080p10le_1.yuv -pix_fmt yuv422p -vf scale=1280x720 -r 5/1 /videos/recv/1920x1080p10le_1.mp4";   
+    ASSERT_EQ(pipeline_string.compare(expected_string) == 0, 1) << "Expected: " << std::endl << expected_string << std::endl << " Got: " << std::endl << pipeline_string << std::endl;
+}
+
+TEST(FFmpegPipelineGeneratorTest, test_recorder) {
+    Config conf;
+    fill_conf_recorder(conf);
+
+    std::string pipeline_string;
+
+    if (ffmpeg_generate_pipeline(conf, pipeline_string) != 0) {
+            ASSERT_EQ(1, 0) << "Error generating convert pipeline" << std::endl;
+    }
+    std::string expected_string = " -y -video_size 1920x1080 -pix_fmt yuv422p10le -r 30/1 -f rawvideo -i /videos/1920x1080p10le_1.yuv -filter_complex \"split=2[in0][in1];[in0]scale=640:360[out0];[in1]scale=1280:720[out1];\" -map \"[out0]\" /videos/recv/recv_1.yuv -map \"[out1]\" -c:v h263p /videos/recv/recv_2.mov";   
     ASSERT_EQ(pipeline_string.compare(expected_string) == 0, 1) << "Expected: " << std::endl << expected_string << std::endl << " Got: " << std::endl << pipeline_string << std::endl;
 }

--- a/gRPC/unit_test/ffmpeg_pipeline_generator_test.cc
+++ b/gRPC/unit_test/ffmpeg_pipeline_generator_test.cc
@@ -216,6 +216,19 @@ TEST(FFmpegPipelineGeneratorTest, test_multiviewer_2) {
     ASSERT_EQ(pipeline_string.compare(expected_string) == 0, 1) << "Expected: " << std::endl << expected_string << std::endl << " Got: " << std::endl << pipeline_string << std::endl;
 }
 
+TEST(FFmpegPipelineGeneratorTest, test_multiviewer_3) {
+    Config conf;
+    fill_conf_multiviewer(conf);
+    conf.gpu_hw_acceleration = "none";
+
+    std::string pipeline_string;
+
+    if (ffmpeg_generate_pipeline(conf, pipeline_string) != 0) {
+            ASSERT_EQ(1, 0) << "Error generating multiviewer pipeline" << std::endl;
+    }
+    std::string expected_string = " -y -video_size 1920x1080 -pix_fmt yuv422p10le -r 30/1 -f rawvideo -i /videos/1920x1080p10le_1.yuv -video_size 1920x1080 -pix_fmt yuv422p10le -r 30/1 -f rawvideo -i /videos/1920x1080p10le_2.yuv -video_size 1920x1080 -pix_fmt yuv422p10le -r 30/1 -f rawvideo -i /videos/1920x1080p10le_1.yuv -video_size 1920x1080 -pix_fmt yuv422p10le -r 30/1 -f rawvideo -i /videos/1920x1080p10le_2.yuv -video_size 1920x1080 -pix_fmt yuv422p10le -r 30/1 -f rawvideo -i /videos/1920x1080p10le_1.yuv -video_size 1920x1080 -pix_fmt yuv422p10le -r 30/1 -f rawvideo -i /videos/1920x1080p10le_2.yuv -video_size 1920x1080 -pix_fmt yuv422p10le -r 30/1 -f rawvideo -i /videos/1920x1080p10le_1.yuv -filter_complex \"[0:v]scale=640:360[out0];[1:v]scale=640:360[out1];[2:v]scale=640:360[out2];[3:v]scale=640:360[out3];[4:v]scale=640:360[out4];[5:v]scale=640:360[out5];[6:v]scale=640:360[out6];[out0][out1][out2][out3][out4][out5][out6]xstack=inputs=7:layout=0_0|640_0|1280_0|0_360|640_360|1280_360|0_720,format=y210le,format=yuv422p10le\" /videos/recv/1920x1080p10le_1.yuv";
+      ASSERT_EQ(pipeline_string.compare(expected_string) == 0, 1) << "Expected: " << std::endl << expected_string << std::endl << " Got: " << std::endl << pipeline_string << std::endl;
+}
 
 TEST(FFmpegPipelineGeneratorTest, test_convert) {
     Config conf;


### PR DESCRIPTION
1. Multiviewer support with or without GPU (intel qsv)
2. Recorder functionality
3. Basic upscale pipeline based on RAISIR library
4. Update Config structure
a) Add multiviewer_columns parameter to specify number of columns (screens per row) for multiviewer functionality
b) Add gpu_hw_acceleration_device to specify device path if Intel gpu is selected
c) Adjust serialization/deserialization  to/from json
d) Add unit test for serialization/deserialization