### PR TITLE
Enable NMOS to handle receiver connections from multiple senders

### DIFF
--- a/docker/nmos/Dockerfile
+++ b/docker/nmos/Dockerfile
@@ -39,8 +39,6 @@ RUN \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-COPY src /tmp
-
 RUN \
     echo "**** DOWNLOAD AND INSTALL gRPC v1.58 ****" && \
     git clone --branch "v1.58.0" --recurse-submodules --depth 1 --shallow-submodules https://github.com/grpc/grpc /tmp/grpc-source && \
@@ -49,6 +47,8 @@ RUN \
     make -C "/tmp/grpc-source/cmake/build" -j$(nproc) && \
     make -C "/tmp/grpc-source/cmake/build" install && \
     rm -rf /tmp/grpc-source
+
+COPY src /tmp
 
 ## Get source for Sony nmos-cpp library
 WORKDIR /tmp

--- a/src/build_local.sh
+++ b/src/build_local.sh
@@ -79,7 +79,8 @@ function build_nmos_cpp_library () {
     cmake .. -DNMOS_CPP_USE_SUPPLIED_JSON_SCHEMA_VALIDATOR=ON \
     -DNMOS_CPP_USE_SUPPLIED_JWT_CPP=ON \
     -DNMOS_CPP_BUILD_EXAMPLES=OFF \
-    -DNMOS_CPP_BUILD_TESTS=OFF && \
+    -DNMOS_CPP_BUILD_TESTS=OFF \
+    -DCMAKE_BUILD_TYPE="Debug" && \
     make -j"$num_proc" && \
     make install
 }
@@ -88,9 +89,9 @@ function build_nmos_node() {
     cd "${SCRIPT_DIR}"/nmos/nmos-node
     mkdir -p build && cd build
     if [ "$UT_OPTION" == "-ut" ]; then
-        cmake .. -DENABLE_UNIT_TESTS=ON
+        cmake .. -DENABLE_UNIT_TESTS=ON -DCMAKE_BUILD_TYPE="Debug"
     else
-        cmake .. -DENABLE_UNIT_TESTS=OFF
+        cmake .. -DENABLE_UNIT_TESTS=OFF -DCMAKE_BUILD_TYPE="Debug"
     fi
     make -j"$num_proc"
 }

--- a/src/nmos/nmos-node/intel_config_parser.cpp
+++ b/src/nmos/nmos-node/intel_config_parser.cpp
@@ -36,6 +36,20 @@ int ConfigManager::parse_json_file(const std::string& file_path) {
         config.function = json_value.at(U("function")).as_string();
         config.gpu_hw_acceleration = json_value.at(U("gpu_hw_acceleration")).as_string();
 
+        if (config.function == "multiviewer") {
+            config.multiviewer_columns = json_value.at(U("multiviewer_columns")).as_integer();
+        }
+        else{
+            config.multiviewer_columns = 3;
+        }
+
+        if (config.gpu_hw_acceleration != "none") {
+            config.gpu_hw_acceleration_device = json_value.at(U("gpu_hw_acceleration_device")).as_string();
+        }
+        else{
+            config.gpu_hw_acceleration_device = "";
+        }
+
         for (const auto& sender : json_value.at(U("sender")).as_array()) {
             std::cout<<"Sender: "<<std::endl;
             config.senders.push_back(parse_stream(sender));
@@ -55,7 +69,9 @@ int ConfigManager::parse_json_file(const std::string& file_path) {
 void ConfigManager::print_config() const {
     std::cout << "Logging Level: " << config.logging_level << std::endl;
     std::cout << "Function: " << config.function << std::endl;
+    std::cout << "[if function is multiviewer] Multiviewer Columns: " << config.multiviewer_columns << std::endl;
     std::cout << "GPU HW Acceleration: " << config.gpu_hw_acceleration << std::endl;
+    std::cout << "[if gpu_hw_acceleration is not none] GPU HW Acceleration Device: " << config.gpu_hw_acceleration_device << std::endl;
 
     for (const auto& sender : config.senders) {
         std::cout << "Sender Video Frame Width: " << sender.payload.video.frame_width << std::endl;

--- a/src/nmos/nmos-node/main.cpp
+++ b/src/nmos/nmos-node/main.cpp
@@ -2,7 +2,7 @@
 #include <iostream>
 #include "cpprest/grant_type.h"
 #include "cpprest/token_endpoint_auth_method.h"
-#include "nmos/api_utils.h" // for make_api_listener
+#include "nmos/api_utils.h"
 #include "nmos/authorization_behaviour.h"
 #include "nmos/authorization_redirect_api.h"
 #include "nmos/authorization_state.h"
@@ -16,9 +16,8 @@
 #include "nmos/ocsp_state.h"
 #include "nmos/process_utils.h"
 #include "nmos/server.h"
-#include "nmos/server_utils.h" // for make_http_listener_config
+#include "nmos/server_utils.h"
 #include "node_implementation.h"
-// #include "config_params.hpp"
 
 #include "intel_config_parser.h"
 
@@ -115,7 +114,9 @@ int main(int argc, char* argv[])
 
         // Set up the callbacks between the node server and the underlying implementation
 
-        auto node_implementation = make_node_implementation(node_model, config_manager, gate);
+        std::vector<Stream> all_receivers;
+
+        auto node_implementation = make_node_implementation(node_model, config_manager, all_receivers, gate);
 
 // only implement communication with OCSP server if http_listener supports OCSP stapling
 // cf. preprocessor conditions in nmos::make_http_listener_config

--- a/src/nmos/nmos-node/node_implementation.cpp
+++ b/src/nmos/nmos-node/node_implementation.cpp
@@ -1006,7 +1006,7 @@ nmos::events_ws_message_handler make_node_implementation_events_ws_message_handl
 }
 
 // Connection API activation callback to perform application-specific operations to complete activation
-nmos::connection_activation_handler make_node_implementation_connection_activation_handler(nmos::node_model& model, ConfigManager& config_manager, std::vector<Stream>& all_receivers, slog::base_gate& gate)
+nmos::connection_activation_handler make_node_implementation_connection_activation_handler(nmos::node_model& model, ConfigManager& config_manager, AppConnectionResources& app_resources, slog::base_gate& gate)
 {
     auto handle_load_ca_certificates = nmos::make_load_ca_certificates_handler(model.settings, gate);
     // this example uses this callback to (un)subscribe a IS-07 Events WebSocket receiver when it is activated
@@ -1017,7 +1017,7 @@ nmos::connection_activation_handler make_node_implementation_connection_activati
     auto connection_events_activation_handler = nmos::make_connection_events_websocket_activation_handler(handle_load_ca_certificates, handle_events_ws_message, handle_close, model.settings, gate);
     // this example uses this callback to update IS-12 Receiver-Monitor connection status
     auto receiver_monitor_connection_activation_handler = nmos::make_receiver_monitor_connection_activation_handler(model.control_protocol_resources);
-    return [connection_events_activation_handler, receiver_monitor_connection_activation_handler, &model, &config_manager, &all_receivers, &gate](const nmos::resource& resource, const nmos::resource& connection_resource)
+    return [connection_events_activation_handler, receiver_monitor_connection_activation_handler, &model, &config_manager, &app_resources, &gate](const nmos::resource& resource, const nmos::resource& connection_resource)
     {
         const std::pair<nmos::id, nmos::type> id_type{ resource.id, resource.type };
         if(id_type.second == nmos::types::sender)
@@ -1094,8 +1094,7 @@ nmos::connection_activation_handler make_node_implementation_connection_activati
             const Config config = {{s}, ffmpeg_receiver_as_file_vector, configIntel.function, configIntel.multiviewer_columns, configIntel.gpu_hw_acceleration, gpu_hw_acceleration_device, configIntel.logging_level};
 
             ffmpegThread1=std::thread(grpc::sendDataToFfmpeg, impl::fields::ffmpeg_grpc_server_address(model.settings), impl::fields::ffmpeg_grpc_server_port(model.settings), config);
-
-            ffmpegThread1.join();
+            app_resources.threads.push_back(std::move(ffmpegThread1));
 }
         if(id_type.second == nmos::types::receiver)
         {
@@ -1191,15 +1190,15 @@ nmos::connection_activation_handler make_node_implementation_connection_activati
                 gpu_hw_acceleration_device = configIntel.gpu_hw_acceleration_device.c_str();
             }
             // construct config for NMOS sender
-            all_receivers.push_back(s);
-            const Config config = {ffmpeg_sender_as_file_vector,all_receivers,configIntel.function,configIntel.multiviewer_columns, configIntel.gpu_hw_acceleration,gpu_hw_acceleration_device, configIntel.logging_level};
+            app_resources.all_receivers.push_back(s);
+            const Config config = {ffmpeg_sender_as_file_vector,app_resources.all_receivers,configIntel.function,configIntel.multiviewer_columns, configIntel.gpu_hw_acceleration,gpu_hw_acceleration_device, configIntel.logging_level};
 
-            if ( all_receivers.size() < configIntel.receivers.size()) {
+            if ( app_resources.all_receivers.size() < configIntel.receivers.size()) {
                 slog::log<slog::severities::error>(gate, SLOG_FLF) << "@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@";
-                slog::log<slog::severities::error>(gate, SLOG_FLF) <<  "RECEIVERS NUMBER DOESN'T MATCH " << all_receivers.size() << ":" << configIntel.receivers.size();
+                slog::log<slog::severities::error>(gate, SLOG_FLF) <<  "RECEIVERS NUMBER DOESN'T MATCH " << app_resources.all_receivers.size() << ":" << configIntel.receivers.size();
             }else{
                 ffmpegThread2=std::thread(grpc::sendDataToFfmpeg, impl::fields::ffmpeg_grpc_server_address(model.settings), impl::fields::ffmpeg_grpc_server_port(model.settings), config);
-                ffmpegThread2.join();
+                app_resources.threads.push_back(std::move(ffmpegThread2));
             }
         }
         connection_events_activation_handler(resource, connection_resource);
@@ -1391,7 +1390,7 @@ namespace impl
 
 // This constructs all the callbacks used to integrate the example device-specific underlying implementation
 // into the server instance for the NMOS Node.
-nmos::experimental::node_implementation make_node_implementation(nmos::node_model& model, ConfigManager& config_manager,std::vector<Stream>& all_receivers, slog::base_gate& gate)
+nmos::experimental::node_implementation make_node_implementation(nmos::node_model& model, ConfigManager& config_manager,AppConnectionResources& app_resources, slog::base_gate& gate)
 {
     return nmos::experimental::node_implementation()
         .on_load_server_certificates(nmos::make_load_server_certificates_handler(model.settings, gate))
@@ -1403,7 +1402,7 @@ nmos::experimental::node_implementation make_node_implementation(nmos::node_mode
         .on_validate_connection_resource_patch(make_node_implementation_patch_validator(gate)) // may be omitted if not required
         .on_resolve_auto(make_node_implementation_auto_resolver(model.settings, gate))
         .on_set_transportfile(make_node_implementation_transportfile_setter(model.node_resources, model.settings, gate))
-        .on_connection_activated(make_node_implementation_connection_activation_handler(model, config_manager, all_receivers, gate))
+        .on_connection_activated(make_node_implementation_connection_activation_handler(model, config_manager, app_resources, gate))
         .on_validate_channelmapping_output_map(make_node_implementation_map_validator()) // may be omitted if not required
         .on_channelmapping_activated(make_node_implementation_channelmapping_activation_handler(gate));
 }

--- a/src/nmos/nmos-node/node_implementation.cpp
+++ b/src/nmos/nmos-node/node_implementation.cpp
@@ -1090,9 +1090,8 @@ nmos::connection_activation_handler make_node_implementation_connection_activati
                 }
                 gpu_hw_acceleration_device = configIntel.gpu_hw_acceleration_device.c_str();
             }
-            int multiviewer_columns = configIntel.function == "multiviewer" ? configIntel.multiviewer_columns : 3;
             // construct config for NMOS sender
-            const Config config = {{s}, ffmpeg_receiver_as_file_vector, configIntel.function, multiviewer_columns, configIntel.gpu_hw_acceleration, gpu_hw_acceleration_device, configIntel.logging_level};
+            const Config config = {{s}, ffmpeg_receiver_as_file_vector, configIntel.function, configIntel.multiviewer_columns, configIntel.gpu_hw_acceleration, gpu_hw_acceleration_device, configIntel.logging_level};
 
             ffmpegThread1=std::thread(grpc::sendDataToFfmpeg, impl::fields::ffmpeg_grpc_server_address(model.settings), impl::fields::ffmpeg_grpc_server_port(model.settings), config);
 
@@ -1191,10 +1190,9 @@ nmos::connection_activation_handler make_node_implementation_connection_activati
                 }
                 gpu_hw_acceleration_device = configIntel.gpu_hw_acceleration_device.c_str();
             }
-            int multiviewer_columns = 3; //configIntel.function == "multiviewer" ? configIntel.multiviewer_columns : 3;
             // construct config for NMOS sender
             all_receivers.push_back(s);
-            const Config config = {ffmpeg_sender_as_file_vector,all_receivers,configIntel.function,multiviewer_columns, configIntel.gpu_hw_acceleration,gpu_hw_acceleration_device, configIntel.logging_level};
+            const Config config = {ffmpeg_sender_as_file_vector,all_receivers,configIntel.function,configIntel.multiviewer_columns, configIntel.gpu_hw_acceleration,gpu_hw_acceleration_device, configIntel.logging_level};
 
             if ( all_receivers.size() < configIntel.receivers.size()) {
                 slog::log<slog::severities::error>(gate, SLOG_FLF) << "@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@";

--- a/src/nmos/nmos-node/node_implementation.cpp
+++ b/src/nmos/nmos-node/node_implementation.cpp
@@ -1085,7 +1085,7 @@ nmos::connection_activation_handler make_node_implementation_connection_activati
 
             auto gpu_hw_acceleration_device = "";
             if (configIntel.gpu_hw_acceleration == "intel") {
-                if (!configIntel.gpu_hw_acceleration_device.empty()) {
+                if (configIntel.gpu_hw_acceleration_device.empty()) {
                     slog::log<slog::severities::error>(gate, SLOG_FLF) << "GPU hardware acceleration device is not specified for Intel.";
                 }
                 gpu_hw_acceleration_device = configIntel.gpu_hw_acceleration_device.c_str();
@@ -1184,20 +1184,22 @@ nmos::connection_activation_handler make_node_implementation_connection_activati
             }
             auto gpu_hw_acceleration_device = "";
             if (configIntel.gpu_hw_acceleration == "intel") {
-                if (!configIntel.gpu_hw_acceleration_device.empty()) {
+                if (configIntel.gpu_hw_acceleration_device.empty()) {
                     slog::log<slog::severities::error>(gate, SLOG_FLF) << "GPU hardware acceleration device is not specified for Intel.";
                 }
                 gpu_hw_acceleration_device = configIntel.gpu_hw_acceleration_device.c_str();
             }
             // construct config for NMOS sender
             app_resources.all_receivers.push_back(s);
-            const Config config = {ffmpeg_sender_as_file_vector,app_resources.all_receivers,configIntel.function,configIntel.multiviewer_columns, configIntel.gpu_hw_acceleration,gpu_hw_acceleration_device, configIntel.logging_level};
+            const Config config = {ffmpeg_sender_as_file_vector,app_resources.all_receivers,configIntel.function,configIntel.multiviewer_columns, \
+                configIntel.gpu_hw_acceleration,gpu_hw_acceleration_device, configIntel.logging_level};
 
             if ( app_resources.all_receivers.size() < configIntel.receivers.size()) {
-                slog::log<slog::severities::error>(gate, SLOG_FLF) << "@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@";
-                slog::log<slog::severities::error>(gate, SLOG_FLF) <<  "RECEIVERS NUMBER DOESN'T MATCH " << app_resources.all_receivers.size() << ":" << configIntel.receivers.size();
+                slog::log<slog::severities::info>(gate, SLOG_FLF) <<  "Waiting for connection to all declared receivers. Connected " << \
+                app_resources.all_receivers.size() << " receivers from declared " << configIntel.receivers.size() << " receivers";
             }else{
-                ffmpegThread2=std::thread(grpc::sendDataToFfmpeg, impl::fields::ffmpeg_grpc_server_address(model.settings), impl::fields::ffmpeg_grpc_server_port(model.settings), config);
+                ffmpegThread2=std::thread(grpc::sendDataToFfmpeg, impl::fields::ffmpeg_grpc_server_address(model.settings), \
+                impl::fields::ffmpeg_grpc_server_port(model.settings), config);
                 app_resources.threads.push_back(std::move(ffmpegThread2));
             }
         }

--- a/src/nmos/nmos-node/node_implementation.h
+++ b/src/nmos/nmos-node/node_implementation.h
@@ -17,6 +17,12 @@ namespace nmos
     }
 }
 
+struct AppConnectionResources
+{
+    std::vector<Stream> all_receivers;
+    std::vector<std::thread> threads;
+};
+
 // This is an example of how to integrate the nmos-cpp library with a device-specific underlying implementation.
 // It constructs and inserts a node resource and some sub-resources into the model, based on the model settings,
 // starts background tasks to emit regular events from the temperature event source, and then waits for shutdown.
@@ -25,6 +31,6 @@ void node_implementation_thread(nmos::node_model& model, nmos::experimental::con
 
 // This constructs all the callbacks used to integrate the example device-specific underlying implementation
 // into the server instance for the NMOS Node.
-nmos::experimental::node_implementation make_node_implementation(nmos::node_model& model, ConfigManager& config_manager, std::vector<Stream>& all_receivers, slog::base_gate& gate);
+nmos::experimental::node_implementation make_node_implementation(nmos::node_model& model, ConfigManager& config_manager, AppConnectionResources& app_resources, slog::base_gate& gate);
 
 #endif

--- a/src/nmos/nmos-node/node_implementation.h
+++ b/src/nmos/nmos-node/node_implementation.h
@@ -25,6 +25,6 @@ void node_implementation_thread(nmos::node_model& model, nmos::experimental::con
 
 // This constructs all the callbacks used to integrate the example device-specific underlying implementation
 // into the server instance for the NMOS Node.
-nmos::experimental::node_implementation make_node_implementation(nmos::node_model& model, ConfigManager& config_manager, slog::base_gate& gate);
+nmos::experimental::node_implementation make_node_implementation(nmos::node_model& model, ConfigManager& config_manager, std::vector<Stream>& all_receivers, slog::base_gate& gate);
 
 #endif

--- a/tests/intel-node-multiviewer.json
+++ b/tests/intel-node-multiviewer.json
@@ -1,0 +1,111 @@
+{
+  "logging_level": -10,
+  "http_port": 95,
+  "label": "intel-broadcast-suite",
+  "senders": ["v"],
+  "senders_count": [0],
+  "receivers": ["v"],
+  "receivers_count": [3],
+  "device_tags": {
+    "pipeline": ["rx"]
+  },
+  "function": "multiviewer",
+  "multiviewer_columns": 3,
+  "gpu_hw_acceleration": "none",
+  "domain": "local",
+  "ffmpeg_grpc_server_address": "localhost",
+  "ffmpeg_grpc_server_port": "50056",
+  "receiver_payload_type":112,
+  "receiver": [{
+    "stream_payload": {
+      "video": {
+        "frame_width": 1920,
+        "frame_height": 1080,
+        "frame_rate": { "numerator": 60, "denominator": 1 },
+        "pixel_format": "yuv422p10le",
+        "video_type": "rawvideo"
+      },
+      "audio": {
+        "channels": 2,
+        "sampleRate": 48000,
+        "format": "pcm_s24be",
+        "packetTime": "1ms"
+      }
+    },
+    "stream_type": {
+        "st2110" : {
+          "transport" : "st2110-20",
+          "payloadType" :  112
+        }
+      }
+  },
+  {
+    "stream_payload": {
+      "video": {
+        "frame_width": 1920,
+        "frame_height": 1080,
+        "frame_rate": { "numerator": 60, "denominator": 1 },
+        "pixel_format": "yuv422p10le",
+        "video_type": "rawvideo"
+      },
+      "audio": {
+        "channels": 2,
+        "sampleRate": 48000,
+        "format": "pcm_s24be",
+        "packetTime": "1ms"
+      }
+    },
+    "stream_type": {
+        "st2110" : {
+          "transport" : "st2110-20",
+          "payloadType" :  112
+        }
+      }
+  },
+  {
+    "stream_payload": {
+      "video": {
+        "frame_width": 1920,
+        "frame_height": 1080,
+        "frame_rate": { "numerator": 60, "denominator": 1 },
+        "pixel_format": "yuv422p10le",
+        "video_type": "rawvideo"
+      },
+      "audio": {
+        "channels": 2,
+        "sampleRate": 48000,
+        "format": "pcm_s24be",
+        "packetTime": "1ms"
+      }
+    },
+    "stream_type": {
+        "st2110" : {
+          "transport" : "st2110-20",
+          "payloadType" :  112
+        }
+      }
+  }],
+  "sender": [{
+    "stream_payload": {
+      "video": {
+        "frame_width": 1920,
+        "frame_height": 1080,
+        "frame_rate": { "numerator": 60, "denominator": 1 },
+        "pixel_format": "yuv422p10le",
+        "video_type": "rawvideo"
+      },
+      "audio": {
+        "channels": 2,
+        "sampleRate": 48000,
+        "format": "pcm_s24be",
+        "packetTime": "1ms"
+      }
+    },
+    "stream_type": {
+      "file": {
+        "path": "/videos/recv",
+        "filename": "1920x1080p10le_3.yuv"
+      }
+    }
+  }]
+}

--- a/tests/intel-node-tx-1.json
+++ b/tests/intel-node-tx-1.json
@@ -1,7 +1,7 @@
 {
   "logging_level": 10,
-  "http_port": 90,
-  "label": "intel-broadcast-suite",
+  "http_port": 100,
+  "label": "intel-broadcast-suite-tx-1",
   "senders": ["v"],
   "senders_count": [1],
   "receivers": ["v"],
@@ -13,7 +13,7 @@
   "gpu_hw_acceleration": "none",
   "domain": "local",
   "ffmpeg_grpc_server_address": "localhost",
-  "ffmpeg_grpc_server_port": "50055",
+  "ffmpeg_grpc_server_port": "50091",
   "sender_payload_type":112,
   "sender": [{
     "stream_payload": {
@@ -57,7 +57,7 @@
     "stream_type": {
       "file": {
         "path": "/videos",
-        "filename": "1920x1080p10le_0.yuv"
+        "filename": "1920x1080p10le_1.yuv"
       }
     }
   }]

--- a/tests/intel-node-tx-2.json
+++ b/tests/intel-node-tx-2.json
@@ -1,7 +1,7 @@
 {
   "logging_level": 10,
-  "http_port": 90,
-  "label": "intel-broadcast-suite",
+  "http_port": 105,
+  "label": "intel-broadcast-suite-tx-2",
   "senders": ["v"],
   "senders_count": [1],
   "receivers": ["v"],
@@ -13,7 +13,7 @@
   "gpu_hw_acceleration": "none",
   "domain": "local",
   "ffmpeg_grpc_server_address": "localhost",
-  "ffmpeg_grpc_server_port": "50055",
+  "ffmpeg_grpc_server_port": "50092",
   "sender_payload_type":112,
   "sender": [{
     "stream_payload": {
@@ -57,7 +57,7 @@
     "stream_type": {
       "file": {
         "path": "/videos",
-        "filename": "1920x1080p10le_0.yuv"
+        "filename": "1920x1080p10le_2.yuv"
       }
     }
   }]

--- a/tests/test_docker_launcher_rx.sh
+++ b/tests/test_docker_launcher_rx.sh
@@ -1,12 +1,20 @@
 #!/bin/bash
 
+if [ $# -ne 2 ]; then
+  echo "Usage: $0 <hostname/ip> <port> e.g. $0 192.168.2.1 50057"
+  exit 1
+fi
+
+HOSTNAME=$1
+PORT=$2
+
 docker run -it \
-   --user root\
+   --user root \
    --privileged \
    --device=/dev/vfio:/dev/vfio \
    --device=/dev/dri:/dev/dri \
    --cap-add ALL \
-   -v "$(pwd)/recv":/videos/recv \
+   -v "$(pwd)":/videos \
    -v /usr/lib/x86_64-linux-gnu/dri:/usr/local/lib/x86_64-linux-gnu/dri/ \
    -v /tmp/kahawai_lcore.lock:/tmp/kahawai_lcore.lock \
    -v /dev/null:/dev/null \
@@ -18,4 +26,4 @@ docker run -it \
    --network=host \
    --ipc=host \
    -v /dev/shm:/dev/shm \
-      tiber-broadcast-suite localhost 50056
+   tiber-broadcast-suite "$HOSTNAME" "$PORT"

--- a/tests/test_docker_launcher_tx.sh
+++ b/tests/test_docker_launcher_tx.sh
@@ -1,7 +1,15 @@
 #!/bin/bash
 
+if [ $# -ne 2 ]; then
+  echo "Usage: $0 <hostname/ip> <port> e.g. $0 192.168.2.1 50057"
+  exit 1
+fi
+
+HOSTNAME=$1
+PORT=$2
+
 docker run -it \
-   --user root\
+   --user root \
    --privileged \
    --device=/dev/vfio:/dev/vfio \
    --device=/dev/dri:/dev/dri \
@@ -18,4 +26,4 @@ docker run -it \
    --network=host \
    --ipc=host \
    -v /dev/shm:/dev/shm \
-      tiber-broadcast-suite localhost 50055
+   tiber-broadcast-suite "$HOSTNAME" "$PORT"

--- a/tests/test_docker_nmos_multiviewer.sh
+++ b/tests/test_docker_nmos_multiviewer.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+docker run -it \
+   --user root\
+   --privileged \
+   --device=/dev/vfio:/dev/vfio \
+   --device=/dev/dri:/dev/dri \
+   --cap-add ALL \
+   -v "$(pwd)":/home/config/ \
+   -v /usr/lib/x86_64-linux-gnu/dri:/usr/local/lib/x86_64-linux-gnu/dri/ \
+   -v /tmp/kahawai_lcore.lock:/tmp/kahawai_lcore.lock \
+   -v /dev/null:/dev/null \
+   -v /tmp/hugepages:/tmp/hugepages \
+   -v /hugepages:/hugepages \
+   -v /var/run/imtl:/var/run/imtl \
+   -e http_proxy="" \
+   -e https_proxy="" \
+   -e VFIO_PORT_RX=0000:31:01.1 \
+   --network=host \
+   --ipc=host \
+   -v /dev/shm:/dev/shm \
+      tiber-broadcast-suite-nmos-node config/intel-node-multiviewer.json

--- a/tests/test_docker_nmos_tx.sh
+++ b/tests/test_docker_nmos_tx.sh
@@ -1,22 +1,81 @@
 #!/bin/bash
 
-docker run -it \
-   --user root\
-   --privileged \
-   --device=/dev/vfio:/dev/vfio \
-   --device=/dev/dri:/dev/dri \
-   --cap-add ALL \
-   -v "$(pwd)":/home/config/ \
-   -v /usr/lib/x86_64-linux-gnu/dri:/usr/local/lib/x86_64-linux-gnu/dri/ \
-   -v /tmp/kahawai_lcore.lock:/tmp/kahawai_lcore.lock \
-   -v /dev/null:/dev/null \
-   -v /tmp/hugepages:/tmp/hugepages \
-   -v /hugepages:/hugepages \
-   -v /var/run/imtl:/var/run/imtl \
-   -e http_proxy="" \
-   -e https_proxy="" \
-   -e VFIO_PORT_TX=0000:31:01.0 \
-   --network=host \
-   --ipc=host \
-   -v /dev/shm:/dev/shm \
+#!/bin/bash
+
+if [ -z "$1" ]; then
+  echo "Usage: $0 <number>"
+  exit 1
+fi
+
+case $1 in
+  0)
+    docker run -it \
+      --user root \
+      --privileged \
+      --device=/dev/vfio:/dev/vfio \
+      --device=/dev/dri:/dev/dri \
+      --cap-add ALL \
+      -v "$(pwd)":/home/config/ \
+      -v /usr/lib/x86_64-linux-gnu/dri:/usr/local/lib/x86_64-linux-gnu/dri/ \
+      -v /tmp/kahawai_lcore.lock:/tmp/kahawai_lcore.lock \
+      -v /dev/null:/dev/null \
+      -v /tmp/hugepages:/tmp/hugepages \
+      -v /hugepages:/hugepages \
+      -v /var/run/imtl:/var/run/imtl \
+      -e http_proxy="" \
+      -e https_proxy="" \
+      -e VFIO_PORT_TX=0000:31:01.0 \
+      --network=host \
+      --ipc=host \
+      -v /dev/shm:/dev/shm \
       tiber-broadcast-suite-nmos-node config/intel-node-tx.json
+    ;;
+  1)
+    docker run -it \
+      --user root \
+      --privileged \
+      --device=/dev/vfio:/dev/vfio \
+      --device=/dev/dri:/dev/dri \
+      --cap-add ALL \
+      -v "$(pwd)":/home/config/ \
+      -v /usr/lib/x86_64-linux-gnu/dri:/usr/local/lib/x86_64-linux-gnu/dri/ \
+      -v /tmp/kahawai_lcore.lock:/tmp/kahawai_lcore.lock \
+      -v /dev/null:/dev/null \
+      -v /tmp/hugepages:/tmp/hugepages \
+      -v /hugepages:/hugepages \
+      -v /var/run/imtl:/var/run/imtl \
+      -e http_proxy="" \
+      -e https_proxy="" \
+      -e VFIO_PORT_TX=0000:31:01.2 \
+      --network=host \
+      --ipc=host \
+      -v /dev/shm:/dev/shm \
+      tiber-broadcast-suite-nmos-node config/intel-node-tx-1.json
+    ;;
+  2)
+    docker run -it \
+      --user root \
+      --privileged \
+      --device=/dev/vfio:/dev/vfio \
+      --device=/dev/dri:/dev/dri \
+      --cap-add ALL \
+      -v "$(pwd)":/home/config/ \
+      -v /usr/lib/x86_64-linux-gnu/dri:/usr/local/lib/x86_64-linux-gnu/dri/ \
+      -v /tmp/kahawai_lcore.lock:/tmp/kahawai_lcore.lock \
+      -v /dev/null:/dev/null \
+      -v /tmp/hugepages:/tmp/hugepages \
+      -v /hugepages:/hugepages \
+      -v /var/run/imtl:/var/run/imtl \
+      -e http_proxy="" \
+      -e https_proxy="" \
+      -e VFIO_PORT_TX=0000:31:01.3 \
+      --network=host \
+      --ipc=host \
+      -v /dev/shm:/dev/shm \
+      tiber-broadcast-suite-nmos-node config/intel-node-tx-2.json
+    ;;
+  *)
+    echo "Invalid number: $1. Please provide 0, 1 or 2."
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
This commit introduces an initial fix that allows NMOS to manage receiver connections from multiple senders, improving the system's flexibility and scalability. Dirty