### PR TITLE
FIX: Update Dockerfile user UID and GID. Build `bcs_pod_launcher` for CI.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -822,7 +822,7 @@ function install_in_docker_enviroment {
     docker buildx build -o "type=image,name=${IMAGE_REGISTRY}/bcs_pod_launcher:${IMAGE_TAG}" "${ENV_PROXY_ARGS[@]}" \
         -t "${IMAGE_REGISTRY}/bcs_pod_launcher:${IMAGE_TAG}" \
         -f "${SCRIPT_DIR}/launcher/Dockerfile" \
-        "${SCRIPT_DIR}launcher"
+        "${SCRIPT_DIR}/launcher"
 
     if [ "${BUILD_TYPE}" != "CI" ]; then
         docker tag "${IMAGE_REGISTRY}/tiber-broadcast-suite:${IMAGE_TAG}" video_production_image:latest

--- a/build.sh
+++ b/build.sh
@@ -819,10 +819,12 @@ function install_in_docker_enviroment {
         --target final-stage \
         "${SCRIPT_DIR}"
 
-    docker buildx build -o "type=image,name=${IMAGE_REGISTRY}/bcs_pod_launcher:${IMAGE_TAG}" "${ENV_PROXY_ARGS[@]}" \
-        -t "${IMAGE_REGISTRY}/bcs_pod_launcher:${IMAGE_TAG}" \
-        -f "${SCRIPT_DIR}/launcher/Dockerfile" \
-        "${SCRIPT_DIR}/launcher"
+    if [ "${BUILD_TYPE}" == "CI" ]; then
+        docker buildx build -o "type=image,name=${IMAGE_REGISTRY}/bcs_pod_launcher:${IMAGE_TAG}" "${ENV_PROXY_ARGS[@]}" \
+          -t "${IMAGE_REGISTRY}/bcs_pod_launcher:${IMAGE_TAG}" \
+          -f "${SCRIPT_DIR}/launcher/Dockerfile" \
+          "${SCRIPT_DIR}/launcher"
+    fi
 
     if [ "${BUILD_TYPE}" != "CI" ]; then
         docker tag "${IMAGE_REGISTRY}/tiber-broadcast-suite:${IMAGE_TAG}" video_production_image:latest

--- a/build.sh
+++ b/build.sh
@@ -819,6 +819,11 @@ function install_in_docker_enviroment {
         --target final-stage \
         "${SCRIPT_DIR}"
 
+    docker buildx build -o "type=image,name=${IMAGE_REGISTRY}/bcs_pod_launcher:${IMAGE_TAG}" "${ENV_PROXY_ARGS[@]}" \
+        -t "${IMAGE_REGISTRY}/bcs_pod_launcher:${IMAGE_TAG}" \
+        -f "${SCRIPT_DIR}/launcher/Dockerfile" \
+        "${SCRIPT_DIR}launcher"
+
     if [ "${BUILD_TYPE}" != "CI" ]; then
         docker tag "${IMAGE_REGISTRY}/tiber-broadcast-suite:${IMAGE_TAG}" video_production_image:latest
         docker tag "${IMAGE_REGISTRY}/mtl-manager:${IMAGE_TAG}" mtl-manager:latest

--- a/docker/nmos/Dockerfile
+++ b/docker/nmos/Dockerfile
@@ -137,7 +137,9 @@ RUN \
 
 HEALTHCHECK --interval=30s --timeout=5s CMD ps aux | grep "bcs-nmos-node" || exit 1
 
-RUN chmod +x /home/entrypoint.sh
+RUN useradd -m -s /bin/bash -u 10001 nmos && \
+    usermod -aG sudo nmos && \
+    chmod +x /home/entrypoint.sh
 
 USER "nmos"
 


### PR DESCRIPTION
[FIX: Build bcs_pod_launcher only for CI - update build.sh](https://github.com/OpenVisualCloud/Intel-Tiber-Broadcast-Suite/pull/139)
FIX: Build bcs_pod_launcher only for CI - update build.sh
Fixed default user `nmos` UID and GID issue.